### PR TITLE
Update regen sslcert

### DIFF
--- a/overlays/turnkey.d/sslcert/usr/lib/inithooks/firstboot.d/15regen-sslcert
+++ b/overlays/turnkey.d/sslcert/usr/lib/inithooks/firstboot.d/15regen-sslcert
@@ -19,7 +19,7 @@ set ${OU:="Software appliances"}
 set ${CN:=$(hostname --fqdn)}
 
 set ${DAYS:=3650}
-set ${BITS:=1024}
+set ${BITS:=2048}
 set ${KEYPASS:=<blank>}           # workaround: no way of passing a blank pass
 set ${CERTFILE:="/etc/ssl/certs/cert.pem"}
 set ${CRTFILE:="/etc/ssl/certs/cert.crt"}


### PR DESCRIPTION
Change SSL cert to add CN equal to the hostname or fully qualified domain name if available.
Changes key length to 2048 bits which is the commonly recommended minimum.
