### PR TITLE
regenerate rails secrets for rails 4.0 and 4.1

### DIFF
--- a/overlays/rails/usr/lib/inithooks/firstboot.d/20regen-rails-secrets
+++ b/overlays/rails/usr/lib/inithooks/firstboot.d/20regen-rails-secrets
@@ -7,17 +7,25 @@ APPNAME=$(cat /etc/hostname)
 [ "$APPNAME" == "rails" ] && APPNAME=railsapp ## namespace conflict
 WEBROOT=/var/www/$APPNAME
 
+# rails 4.1
+CONF=$WEBROOT/config/secrets.yml
+[ -e $CONF ] && sed -i "s|secret_key_base:.*|secret_key_base: '$(mcookie)$(mcookie)$(mcookie)$(mcookie)'|" $CONF
+
+# rails 4.0
+CONF=$WEBROOT/config/initializers/secret_token.rb
+[ -e $CONF ] && sed -i "s|Application.config.secret_key_base\\s*=.*|Application.config.secret_key_base = '$(mcookie)$(mcookie)$(mcookie)$(mcookie)'|" $CONF
+
 # rails 3.2
 CONF=$WEBROOT/config/initializers/secret_token.rb
-[ -e $CONF ] && sed -i "s|Application.config.secret_token =.*|Application.config.secret_token = '$(mcookie)$(mcookie)$(mcookie)$(mcookie)'|" $CONF
+[ -e $CONF ] && sed -i "s|Application.config.secret_token\\s*=.*|Application.config.secret_token = '$(mcookie)$(mcookie)$(mcookie)$(mcookie)'|" $CONF
 
 # rails 2.3
 CONF=$WEBROOT/config/initializers/session_store.rb
-[ -e $CONF ] && sed -i "s|:secret      => .*|:secret      => \'$(mcookie)$(mcookie)\'|" $CONF
+[ -e $CONF ] && sed -i "s|:secret\\s*=>.*|:secret => \'$(mcookie)$(mcookie)\'|" $CONF
 
 # rails 2.2
 CONF=$WEBROOT/config/site.yml
-[ -e $CONF ] && sed -i "s|^salt: .*|salt: \"$(mcookie)\"|" $CONF
+[ -e $CONF ] && sed -i "s|^salt:.*|salt: \"$(mcookie)\"|" $CONF
 
 # regen mysql password
 PASSWORD=$(mcookie)


### PR DESCRIPTION
And be just a bit less restrictive for older versions.

I've tested this locally, though not as part of a new turnkeylinux build (which takes a lot of resources).
