### PR TITLE
make vim.tiny alternative for vim (instead of symlink)

### DIFF
--- a/conf/turnkey.d/vim.tiny
+++ b/conf/turnkey.d/vim.tiny
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 VIMTINY=$(which vim.tiny)
-[ "$VIMTINY" ] && ln -s $VIMTINY /usr/local/bin/vim
+[ "$VIMTINY" ] && update-alternatives --install /usr/bin/vim vim /usr/bin/vim.tiny 10
 
 exit 0


### PR DESCRIPTION
Closes [#300 ](https://github.com/turnkeylinux/tracker/issues/300) 

IMO a neater way of making vim.tiny open with `vim` command in TurnKey but will automatically update `vim` to point to full vim (aka vim.basic) if installed.

I have tested this both in a pre-installed Core; but also by using my patched `common` to build a new Core iso (just to be 100% sure) and it works sweet! :) `vim` launches vim.tiny as per current behaviour, but if full vim is installed (`apt-get install vim`) `vim` command will launch vim.basic (as users would expect).

What do you think?