### PR TITLE
Update apache-credit

### DIFF
--- a/conf/apache-credit
+++ b/conf/apache-credit
@@ -54,7 +54,7 @@ set ${CREDIT_LOCATION:=/}
 cat > /etc/apache2/mods-available/substitute.conf<<EOF
 # Support TurnKey Linux by adding credit to footer
 <Location $CREDIT_LOCATION>
-    AddOutputFilterByType SUBSTITUTE text/html
+    AddOutputFilterByType INFLATE;SUBSTITUTE;DEFLATE text/html
     Substitute "s|</head>|$(strip "$HEAD")</head>|i"
     Substitute "s|</body>|$(strip "$BODY")</body>|i"
 </Location>


### PR DESCRIPTION
I updated the AddOutputFilter statement to specify the order of filters.

This seems necessary in Debian Jessie to display the credit, without this order, appliances (I only saw WordPress) don't show the creditline