### PR TITLE
added kernel entry to stop console sleeping

### DIFF
--- a/overlays/turnkey.d/grub/etc/default/grub
+++ b/overlays/turnkey.d/grub/etc/default/grub
@@ -6,7 +6,7 @@ GRUB_HIDDEN_TIMEOUT=0
 GRUB_HIDDEN_TIMEOUT_QUIET=false
 GRUB_TIMEOUT=3
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
-GRUB_CMDLINE_LINUX_DEFAULT=""
+GRUB_CMDLINE_LINUX_DEFAULT="consoleblank=0"
 GRUB_CMDLINE_LINUX=""
 
 # Uncomment to disable graphical terminal (grub-pc only)


### PR DESCRIPTION
Not sure if this is the best way to go about this, but it works!

I tested making adjustments to /etc/kbd/conf but they don't seem to do anything... 

I also read that it should be able to be adjusted within ~/.profile, but I couldn't get that to work either.
 
The only other way that it seems we can stop the console from going to sleep is by installing additional software. 

Closes https://github.com/turnkeylinux/tracker/issues/343