### PR TITLE
updated default git project root (Jessie update; see git changelog - …

### DIFF
--- a/conf/create-repos
+++ b/conf/create-repos
@@ -28,7 +28,7 @@ export GIT_AUTHOR_EMAIL=root@localhost
 dvcs_repo git
 
 touch $REPOS/git/helloworld/.git/git-daemon-export-ok
-GITPUB=/var/cache/git
+GITPUB=/var/lib/git
 ln -s $REPOS/git/helloworld/.git $GITPUB/helloworld.git
 ln -s $GITPUB $REPOS/git/public
 echo "Hello World" > $REPOS/git/helloworld/.git/description


### PR DESCRIPTION
…1:1.8.4~rc0-1)

from http://metadata.ftp-master.debian.org/changelogs//main/g/git/git_2.1.4-2.1_changelog

>git (1:1.8.4~rc0-1) unstable; urgency=low

>* new upstream release candidate.
>* use /var/lib/git instead of /var/cache/git as default git
    project root to comply with the Filesystem Hierarchy Standard
    (thx Julian Gilbey; closes: #483788):
    * git-daemon.default, git-daemon.in, git-daemon/run: use
      base path of /var/lib and projectroot of /var/lib/git.
    * gitweb.conf: $projectroot = "/var/lib/git".
    * rules: package git: install empty /var/lib/git directory
      instead of /var/cache/git.