### PR TITLE
Update lamp and lapp make files to use new adminer overlay

### DIFF
--- a/mk/turnkey/lamp.mk
+++ b/mk/turnkey/lamp.mk
@@ -1,6 +1,6 @@
 WEBMIN_FW_TCP_INCOMING = 22 80 443 12320 12321 12322
 
-COMMON_OVERLAYS += apache adminer-apache confconsole-lamp
+COMMON_OVERLAYS += apache adminer confconsole-lamp
 COMMON_CONF += phpsh apache-vhost postfix-local adminer-apache
 
 include $(FAB_PATH)/common/mk/turnkey/php.mk

--- a/mk/turnkey/lapp.mk
+++ b/mk/turnkey/lapp.mk
@@ -1,6 +1,6 @@
 WEBMIN_FW_TCP_INCOMING = 22 80 443 12320 12321 12322
 
-COMMON_OVERLAYS += apache adminer-apache confconsole-lapp
+COMMON_OVERLAYS += apache adminer confconsole-lapp
 COMMON_CONF += phpsh apache-vhost postfix-local adminer-apache
 
 include $(FAB_PATH)/common/mk/turnkey/php.mk


### PR DESCRIPTION
Changed lamp and lapp make files to use the adminer overlay. Replaces the adminer-apache overlay since this file is included in the adminer overlay.

Tested and built lamp/lapp twice with no build issues. See (https://github.com/turnkeylinux/tracker/issues/403) for dialog

@alonswartz I would have added this with #35 but I did not know that lamp/lapp code was in common. Sorry bout that, I'll do my homework next time!