### PR TITLE
Adminer updates for db selection for lamp and lapp and others

### DIFF
--- a/conf/adminer-mysql
+++ b/conf/adminer-mysql
@@ -1,0 +1,25 @@
+#!/bin/sh -e
+
+# adminer-mysql
+#
+#   common conf script to configure adminer to only show mysql
+#   database option and localhost for server.
+#   Also removes version checking code
+
+ADMINER_DIR=/usr/share/adminer/adminer/include
+ADMINER_BOOTSTRAP=$ADMINER_DIR/bootstrap.inc.php
+
+
+# Comment out uneeded db options
+sed -i '/^include "..\/adminer\/drivers\/sqlite.inc.php"/ s|include|\/\/ include|' $ADMINER_BOOTSTRAP
+sed -i '/^include "..\/adminer\/drivers\/pgsql.inc.php"/ s|include|\/\/ include|' $ADMINER_BOOTSTRAP
+sed -i '/^include "..\/adminer\/drivers\/oracle.inc.php"/ s|include|\/\/ include|' $ADMINER_BOOTSTRAP
+sed -i '/^include "..\/adminer\/drivers\/mssql.inc.php"/ s|include|\/\/ include|' $ADMINER_BOOTSTRAP
+
+
+# Set localhost as default database
+sed -i '/^define("SERVER", \$_GET\[DRIVER\])/ s|\$_GET\[DRIVER\]|"localhost"|' $ADMINER_BOOTSTRAP
+
+
+# Remove version checking
+sed -i '/^<a href="http:\/\/www.adminer.org\/#download" id="version">/ s|.*||' $ADMINER_DIR/adminer.inc.php

--- a/conf/adminer-pgsql
+++ b/conf/adminer-pgsql
@@ -1,0 +1,25 @@
+#!/bin/sh -e
+
+# adminer-pgsql
+#
+#   common conf script to configure adminer to only show pgsql
+#   database option and localhost for server.
+#   Also removes version checking code
+
+ADMINER_DIR=/usr/share/adminer/adminer/include
+ADMINER_BOOTSTRAP=$ADMINER_DIR/bootstrap.inc.php
+
+
+# Comment out uneeded db options
+sed -i '/^include "..\/adminer\/drivers\/sqlite.inc.php"/ s|include|\/\/ include|' $ADMINER_BOOTSTRAP
+sed -i '/^include "..\/adminer\/drivers\/oracle.inc.php"/ s|include|\/\/ include|' $ADMINER_BOOTSTRAP
+sed -i '/^include "..\/adminer\/drivers\/mssql.inc.php"/ s|include|\/\/ include|' $ADMINER_BOOTSTRAP
+sed -i '/^include "..\/adminer\/drivers\/mysql.inc.php"/ s|include|\/\/ include|' $ADMINER_BOOTSTRAP
+
+
+# Set localhost as default database
+sed -i '/^define("SERVER", \$_GET\[DRIVER\])/ s|\$_GET\[DRIVER\]|"localhost"|' $ADMINER_BOOTSTRAP
+
+
+# Remove version checking
+sed -i '/^<a href="http:\/\/www.adminer.org\/#download" id="version">/ s|.*||' $ADMINER_DIR/adminer.inc.php

--- a/mk/turnkey/lamp.mk
+++ b/mk/turnkey/lamp.mk
@@ -1,7 +1,7 @@
 WEBMIN_FW_TCP_INCOMING = 22 80 443 12320 12321 12322
 
 COMMON_OVERLAYS += apache adminer confconsole-lamp
-COMMON_CONF += phpsh apache-vhost postfix-local adminer-apache
+COMMON_CONF += phpsh apache-vhost postfix-local adminer-apache adminer-mysql
 
 include $(FAB_PATH)/common/mk/turnkey/php.mk
 include $(FAB_PATH)/common/mk/turnkey/mysql.mk

--- a/mk/turnkey/lapp.mk
+++ b/mk/turnkey/lapp.mk
@@ -1,7 +1,7 @@
 WEBMIN_FW_TCP_INCOMING = 22 80 443 12320 12321 12322
 
 COMMON_OVERLAYS += apache adminer confconsole-lapp
-COMMON_CONF += phpsh apache-vhost postfix-local adminer-apache
+COMMON_CONF += phpsh apache-vhost postfix-local adminer-apache adminer-pgsql
 
 include $(FAB_PATH)/common/mk/turnkey/php.mk
 include $(FAB_PATH)/common/mk/turnkey/pgsql.mk


### PR DESCRIPTION
Adds conf scripts to configure adminer to specific database mysql or pgsql and sets default database to localhost. Will also use these for mysql and postgres appliances as well. 

Also changes lamp/lapp make files to use new adminer changes