### PR TITLE
add etckeeper gc cron.weekly job

### DIFF
--- a/overlays/turnkey.d/etckeeper/etc/cron.weekly/etckeeper-gc
+++ b/overlays/turnkey.d/etckeeper/etc/cron.weekly/etckeeper-gc
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+#
+# weekly cron job to do garebage collection for etckeeper 
+
+# only run if git is installed & /etc is git repo
+if [ -f /usr/bin/git ] && [ -d /etc/.git ]; then
+    cd /etc
+    /usr/bin/git gc --auto --quiet
+fi


### PR DESCRIPTION
TBH I'm actually not sure if this is still needed...!?

I saw this old issue on the tracker and thought I'd quickly fix it. After doing this I realised that there was already a `git gc` implemented into etckeeper (see [this forum post](http://www.turnkeylinux.org/forum/support/20111111/etckeeper-has-huge-git-repo-how-remove#comment-10813))
````
/etc/etckeeper/post-install.d/99git-gc

#!/bin/sh
# run git garbage collection after each apt run (Thank Jeremiah!)
exec git gc
````
I double checked on a couple of TKL servers I have running - it cleaned up a little bit (a few hundred KB on my TKLDev v14.0rc1 servers & ~2MB on an old v12.1 server). I figure since I used the `--auto` switch (so it only does the gc if it needs to) then it shouldn't cause any issues and will only run if need be...

Regardless of whether this get's merged or closed; this PR closes turnkeylinux/tracker/issues/256