### PR TITLE
NodeJS fixes

### DIFF
--- a/conf/nodejs
+++ b/conf/nodejs
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 
 # nodejs service
-adduser --system --disabled-login --group --no-create-home nodejs
+adduser --system --disabled-login --group nodejs
 update-rc.d -f nodejs defaults || true
 touch /var/log/nodejs.log
 chown nodejs:nodejs /var/log/nodejs.log

--- a/overlays/nodejs/etc/nginx/sites-available/nodejs
+++ b/overlays/nodejs/etc/nginx/sites-available/nodejs
@@ -5,6 +5,9 @@ server {
 
 server {
     listen 0.0.0.0:443 ssl;
+
+    proxy_set_header X-Forwarded-Proto https;
+
     include /etc/nginx/include/ssl;
     include /etc/nginx/include/nodejs-proxy;
 }


### PR DESCRIPTION
e744402 allows the nodejs user to install npm packages. This is necessary for e. g. installing Etherpad addons and I imagine would be useful overall.

Also reflects the recent security-hardening changes.