### PR TITLE
fix vim arrow keys that display A B C D on remote shell

### DIFF
--- a/conf/turnkey.d/vim.tiny
+++ b/conf/turnkey.d/vim.tiny
@@ -3,4 +3,7 @@
 VIMTINY=$(which vim.tiny)
 [ "$VIMTINY" ] && update-alternatives --install /usr/bin/vim vim /usr/bin/vim.tiny 10
 
+# fix vim arrow keys that display A B C D on remote shell
+sed -i "s/ compatible/ nocompatible/" /etc/vim/vimrc.tiny
+
 exit 0


### PR DESCRIPTION
Please fix my pet peeve about vim.tiny.

Reference: http://vim.wikia.com/wiki/Fix_arrow_keys_that_display_A_B_C_D_on_remote_shell