### PR TITLE
Webserver removelist

### DIFF
--- a/removelists/turnkey
+++ b/removelists/turnkey
@@ -10,3 +10,5 @@
 /var/log/bootstrap.log
 /var/log/apt/term.log
 /var/log/apt/history.log
+
+/var/www/html


### PR DESCRIPTION
This removes the default /var/www/html directory that Debian now uses as default for all webserver. As discussed, we disagree with that practice and don't want to force that change to our users.

Putting it in common and applying it to all servers is a blunt instrument; but I have tested it and it works well.; When a webserver (apache/lightty/nginx) is not installed it fails gracefully and does nothing (i.e. does not make the build crash).

Hopefully you are ok with this approach...