### PR TITLE
turnkey-make-ssl-cert: use hostname only if there are no FQDNs available

### DIFF
--- a/overlays/turnkey.d/sslcert/usr/local/bin/turnkey-make-ssl-cert
+++ b/overlays/turnkey.d/sslcert/usr/local/bin/turnkey-make-ssl-cert
@@ -172,6 +172,7 @@ create_temporary_cnf() {
     done
   else
     [[ "$args" == "" ]] && args="$(hostname -A)"
+    [[ "$args" == "" ]] && args="$(hostname)"
     for fqdn in $args
     do
       add_san "$fqdn";                      # fqdn


### PR DESCRIPTION
Because what else can we use for the CN? The IP is a bigger information disclosure than the hostname since it could leak network topology.
Without this, openssl called from turnkey-make-ssl-cert fails on empty CN.