### PR TITLE
pgsqlconf.py: su into a login shell

### DIFF
--- a/overlays/pgsql/usr/lib/inithooks/bin/pgsqlconf.py
+++ b/overlays/pgsql/usr/lib/inithooks/bin/pgsqlconf.py
@@ -67,7 +67,7 @@ class PostgreSQL:
         self._stop()
 
     def execute(self, query):
-        p = Popen("su postgres -c 'psql -q %s'" % self.database, shell=True, stdin=PIPE)
+        p = Popen("su postgres -lc 'psql -q %s'" % self.database, shell=True, stdin=PIPE)
         p.communicate(query)
         if p.returncode != 0:
             raise ExecError("postgres command failed")


### PR DESCRIPTION
Prevents the error about being unable to change directory to /root on su invocation.