### PR TITLE
Make Samba handle sudoadmin

### DIFF
--- a/overlays/samba-fileserver/usr/lib/inithooks/firstboot.d/35samba-sudoadmin
+++ b/overlays/samba-fileserver/usr/lib/inithooks/firstboot.d/35samba-sudoadmin
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+# adapt samba to admin user
+
+[ -n "$_TURNKEY_INIT" ] && exit 0
+
+. /etc/default/inithooks
+
+if [ "$(echo $SUDOADMIN | tr [A-Z] [a-z] )" = "true" ]; then
+    USERNAME=admin
+    sed -i "s/\(admin users =\) .*/\1 $USERNAME/" /etc/samba/smb.conf
+
+    (echo "$ROOT_PASS" ; echo "$ROOT_PASS" ) | smbpasswd -a -s $USERNAME
+    smbpasswd -d root
+    service samba reload
+fi
+


### PR DESCRIPTION
* sets the Samba admin user to «admin»
* sets the password
* deactivates the root user

Not sure if the number is right. Also, this is basically a version of https://github.com/turnkeylinux/common/blob/master/conf/samba-rootpass which proved to be sufficient.