### PR TITLE
Fix lighty conf issue

### DIFF
--- a/conf/adminer-lighttpd
+++ b/conf/adminer-lighttpd
@@ -3,9 +3,6 @@
 # Enable redirection so we can force adminer to use ssl via redirect mod
 sed -i "/^#.*\"mod_redirect\"/ s/#/ /" /etc/lighttpd/lighttpd.conf
 
-# Change default port to 8888
-sed -i "/^server.port.*=.*80/ s/80/8888/" /etc/lighttpd/lighttpd.conf
-
 # Disable default SSL site
 lighty-disable-mod ssl || true
 


### PR DESCRIPTION
Remove sed line replacing default port 80 with port 8888 so everything
displays on correct port.

closes https://github.com/turnkeylinux/tracker/issues/611