### PR TITLE
Install LTS instead of latest stable Node to avoid build failures

### DIFF
--- a/conf/nodejs-install
+++ b/conf/nodejs-install
@@ -5,8 +5,8 @@ cd /usr/local/src
 git clone https://github.com/tj/n
 cd n && make install
 
-# install latest stable node
-n stable
+# install latest LTS node
+n lts
 
 # user-global npm installation: we don't need root for npm global installs
 


### PR DESCRIPTION
Turns out that when Node.js is concerned, `stable` is not so stable after all…