### PR TITLE
Set lvm/no_boot debconf option in installed rootfs

### DIFF
--- a/conf/turnkey.d/lvm-no-boot
+++ b/conf/turnkey.d/lvm-no-boot
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo 'di-live partman-auto-lvm/no_boot boolean true' | debconf-set-selections


### PR DESCRIPTION
Fixes one half of https://github.com/turnkeylinux/tracker/issues/782