### PR TITLE
Include better default config for vim-tiny

### DIFF
--- a/overlays/turnkey.d/vim-tiny-config/etc/vim/vimrc.local
+++ b/overlays/turnkey.d/vim-tiny-config/etc/vim/vimrc.local
@@ -1,0 +1,1 @@
+set tabstop=4 shiftwidth=4 expandtab softtabstop=0


### PR DESCRIPTION
Resolves https://github.com/turnkeylinux/tracker/issues/763

`autocmd` is not available in vim-tiny, and neither is `filetype`.