### PR TITLE
Add dehydrated

### DIFF
--- a/conf/turnkey.d/ssl-dehydrated
+++ b/conf/turnkey.d/ssl-dehydrated
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+apt-get update -q
+apt-get install dehydrated -y
+

--- a/overlays/turnkey.d/dehydrated/etc/apt/preferences.d/dehydrated-backports.pref
+++ b/overlays/turnkey.d/dehydrated/etc/apt/preferences.d/dehydrated-backports.pref
@@ -1,0 +1,5 @@
+Explanation: Pin dehydrated from backports
+Package: dehydrated
+Pin: release a=jessie-backports
+Pin-Priority: 500
+

--- a/overlays/turnkey.d/dehydrated/etc/apt/sources.list.d/backports.sources.list
+++ b/overlays/turnkey.d/dehydrated/etc/apt/sources.list.d/backports.sources.list
@@ -1,0 +1,6 @@
+# Jessie Backports repo
+
+deb http://httpredir.debian.org/debian jessie-backports main
+
+# deb http://httpredir.debian.org/debian jessie-backports contrib 
+# deb http://httpredir.debian.org/debian jessie-backports non-free

--- a/plans/turnkey/base
+++ b/plans/turnkey/base
@@ -76,6 +76,9 @@ bsd-mailx
 postfix
 webmin-postfix
 
+authbind       /* add-water (confconsole lets encrypt) depends */
+python-bottle  /* add-water (confconsole lets encrypt) depends */
+
 #ifndef CHROOT_ONLY
 acpi-support-base
 #endif


### PR DESCRIPTION
These 2 commits add `dehydrated` (Let's Encrypt ACME SSL certificate client written in BASH) and dependencies for the upcoming Let's Encrypt SSL Cert integration into TurnKey (via Confconsole)