### PR TITLE
explicitly added libperl4-corelibs-perl to lamp & lapp plans

### DIFF
--- a/plans/turnkey/lamp
+++ b/plans/turnkey/lamp
@@ -12,3 +12,4 @@ webmin-phpini
 adminer
 php5-cli
 
+libperl4-corelibs-perl # php5-common depends on lsof; which depends on this

--- a/plans/turnkey/lapp
+++ b/plans/turnkey/lapp
@@ -11,3 +11,4 @@ webmin-postgresql
 adminer
 php5-cli
 
+libperl4-corelibs-perl # php5-common depends on lsof; which depends on this


### PR DESCRIPTION
Nopt sure if anyone else was having issues with this, but the last few weeks I've found issues installing lsof (PHP5 dependency) when building LAMP and LAPP based appliances. If this dependency is included it installs fine...