### PR TITLE
add TIMEOUTclose = 0 to stunnel.conf. Closes #833

### DIFF
--- a/conf/turnkey.d/shellinabox
+++ b/conf/turnkey.d/shellinabox
@@ -15,6 +15,7 @@ cat >>/etc/stunnel/stunnel.conf<<EOF
 [shellinabox]
 accept  = 12320
 connect = 127.0.0.1:12319
+TIMEOUTclose = 0
 
 EOF
 

--- a/conf/turnkey.d/webmin-conf-stunnel
+++ b/conf/turnkey.d/webmin-conf-stunnel
@@ -7,6 +7,7 @@ cat >>/etc/stunnel/stunnel.conf<<EOF
 [webmin]
 accept  = $WEBMIN_PORT
 connect = 127.0.0.1:10000
+TIMEOUTclose = 0
 EOF
 
 CONF=/etc/webmin/miniserv.conf


### PR DESCRIPTION
This PR changes the scripts in turnkeylinux/common that add the shellinabox and webmin sections to /etc/stunnel/stunnel.conf.  This corrects the problem reported in issue #833 on the tracker.