### PR TITLE
force non-interactive dehydrated install from backports

### DIFF
--- a/conf/turnkey.d/ssl-dehydrated
+++ b/conf/turnkey.d/ssl-dehydrated
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
 apt-get update -q
-apt-get install dehydrated -y
+
+# OTRS appliance fails to build without forcing non-interactive install
+# but still fails because when Dehydrated is installed apt returns a non-zero
+# exit code (because OTRS still not configured properly)
+
+DEBIAN_FRONTEND=noninteractive apt-get install dehydrated -y || true
 


### PR DESCRIPTION
The OTRS appliance package appears to be a little buggy. By default it fails to install on first run. We are currently working around that by reconfiguring the package during the conf script.

However, the installation of Dehydrated from Jessie-backports (without forcing non-interactive install) was breaking the OTRS appliance build (when Dehydrated is installed apt returns a non-zero exit code -
 because OTRS still not configured properly).

This tweak resolves that.