### PR TITLE
Reconfigure mysql-server on boot

### DIFF
--- a/overlays/mysql/usr/lib/inithooks/firstboot.d/20regen-mysql-secrets
+++ b/overlays/mysql/usr/lib/inithooks/firstboot.d/20regen-mysql-secrets
@@ -3,5 +3,4 @@
 
 . /etc/default/inithooks
 
-PASSWORD=$(mcookie | head -c 16)
-$INITHOOKS_PATH/bin/mysqlconf.py --user debian-sys-maint --pass="$PASSWORD"
+dpkg-reconfigure -f noninteractive mysql-server-5.5


### PR DESCRIPTION
Re-enable debian-sys-maint mysql account, so mysql is actually usable after https://github.com/turnkeylinux/buildtasks/pull/48
