### PR TITLE
Hardening for version 15.0

### DIFF
--- a/conf/turnkey.d/postfix-local
+++ b/conf/turnkey.d/postfix-local
@@ -8,6 +8,9 @@ fi
 postconf -e inet_interfaces=localhost
 postconf -e myhostname=$HOSTNAME
 
+# harden postfix banner
+postconf -e smtpd_banner='$myhostname ESMTP'
+
 /etc/init.d/postfix start
 /etc/init.d/postfix stop
 

--- a/conf/turnkey.d/roothome
+++ b/conf/turnkey.d/roothome
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
+# harden ssh client directories
+mkdir -m 0700 /etc/skel/.ssh
+umask 0077 && touch /etc/skel/.ssh/.anchor
+cp -dRn /etc/skel/.ssh /root
+
 cp /etc/skel/.bashrc /root
 [ -d /etc/skel/.bashrc.d ] && cp -dRn /etc/skel/.bashrc.d /root
 

--- a/conf/turnkey.d/roothome
+++ b/conf/turnkey.d/roothome
@@ -2,7 +2,6 @@
 
 # harden ssh client directories
 mkdir -m 0700 /etc/skel/.ssh
-umask 0077 && touch /etc/skel/.ssh/.anchor
 cp -dRn /etc/skel/.ssh /root
 
 cp /etc/skel/.bashrc /root

--- a/conf/turnkey.d/sshd
+++ b/conf/turnkey.d/sshd
@@ -6,6 +6,29 @@ sed -i "/^PermitRootLogin/ s/without-password/yes/" /etc/ssh/sshd_config
 # disable sshd dns checks (if resolution fails will prevent logins)
 echo "UseDNS no" >> /etc/ssh/sshd_config
 
+# harden ssh daemon
+sed -i '{
+  /^UsePrivilegeSeparation/ d
+  /^X11Forwarding/ d
+  /^TCPKeepAlive/ d
+  /^AllowTcpForwarding/ d
+  /^ClientAliveCountMax/ d
+  /^MaxAuthTries/ d
+  /^MaxSessions/ d
+}' /etc/ssh/sshd_config
+
+cat >> /etc/ssh/sshd_config <<EOF
+
+# SSH hardening recommended by lynis
+UsePrivilegeSeparation sandbox
+X11Forwarding no
+TCPKeepAlive no
+AllowTcpForwarding no
+ClientAliveCountMax 2
+MaxAuthTries 2
+MaxSessions 2
+EOF
+
 # configure root login banner directive (enabled by inithooks#sudoadmin)
 cat >> /etc/ssh/sshd_config <<EOF
 
@@ -13,18 +36,4 @@ Match user root
 Banner /root/.ssh/banner
 Match user *
 EOF
-
-# harden ssh daemon
-sed -i '{
-  /^UsePrivilegeSeparation/ s/yes/sandbox/
-  /^X11Forwarding/ s/yes/no/
-  /^TCPKeepAlive/ s/yes/no/
-  /^UsePrivilegeSeparation/ a\
-\
-# SSH hardening recommended by lynis\
-AllowTcpForwarding no\
-ClientAliveCountMax 2\
-MaxAuthTries 2\
-MaxSessions 2
-}' /etc/ssh/sshd_config
 

--- a/conf/turnkey.d/sshd
+++ b/conf/turnkey.d/sshd
@@ -14,3 +14,17 @@ Banner /root/.ssh/banner
 Match user *
 EOF
 
+# harden ssh daemon
+sed -i '{
+  /^UsePrivilegeSeparation/ s/yes/sandbox/
+  /^X11Forwarding/ s/yes/no/
+  /^TCPKeepAlive/ s/yes/no/
+  /^UsePrivilegeSeparation/ a\
+\
+# SSH hardening recommended by lynis\
+AllowTcpForwarding no\
+ClientAliveCountMax 2\
+MaxAuthTries 2\
+MaxSessions 2
+}' /etc/ssh/sshd_config
+

--- a/overlays/turnkey.d/sysctl/etc/sysctl.d/10-hardening.conf
+++ b/overlays/turnkey.d/sysctl/etc/sysctl.d/10-hardening.conf
@@ -1,5 +1,5 @@
 #
-# /etc/sysctl.d/90-hardening.conf - Configuration file
+# /etc/sysctl.d/10-hardening.conf - Configuration file
 # for hardening system variables as recommended by Lynis.
 #
 # Settings can be overridden in /etc/sysctl.conf.

--- a/overlays/turnkey.d/sysctl/etc/sysctl.d/90-hardening.conf
+++ b/overlays/turnkey.d/sysctl/etc/sysctl.d/90-hardening.conf
@@ -1,0 +1,69 @@
+#
+# /etc/sysctl.d/90-hardening.conf - Configuration file
+# for hardening system variables as recommended by Lynis.
+#
+# Settings can be overridden in /etc/sysctl.conf.
+# See /etc/sysctl.d/ for additional system variables.
+# See sysctl.conf (5) for information.
+#
+##############################################################3
+# Harden kernel recommendations by Lynis
+fs.suid_dumpable = 0
+kernel.core_uses_pid = 1
+kernel.dmesg_restrict = 1
+kernel.kptr_restrict = 2
+kernel.sysrq = 0
+
+
+##############################################################3
+# Functions previously found in netbase
+#
+
+# Enable Spoof protection (reverse-path filter)
+# Turn on Source Address Verification in all interfaces to
+# prevent some spoofing attacks
+net.ipv4.conf.default.rp_filter = 1
+net.ipv4.conf.all.rp_filter = 1
+
+# Enable TCP/IP SYN cookies
+# See http://lwn.net/Articles/277146/
+# Note: This may impact IPv6 TCP sessions too
+net.ipv4.tcp_syncookies = 1
+
+# Enable packet forwarding for IPv4
+net.ipv4.conf.all.forwarding = 0
+
+# Enable packet forwarding for IPv6
+#  Enabling this option disables Stateless Address Autoconfiguration
+#  based on Router Advertisements for this host
+net.ipv6.conf.all.forwarding = 0
+
+
+###################################################################
+# Additional settings - these settings can improve the network
+# security of the host and prevent against some network attacks
+# including spoofing attacks and man in the middle attacks through
+# redirection. Some network environments, however, require that these
+# settings are disabled so review and enable them as needed.
+#
+# Do not accept ICMP redirects (prevent MITM attacks)
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0
+net.ipv6.conf.all.accept_redirects = 0
+net.ipv6.conf.default.accept_redirects = 0
+#
+# Do not send ICMP redirects (we are not a router)
+net.ipv4.conf.all.send_redirects = 0
+net.ipv6.conf.all.send_redirects = 0
+#
+# Do not accept IP source route packets (we are not a router)
+net.ipv4.conf.all.accept_source_route = 0
+net.ipv6.conf.all.accept_source_route = 0
+#
+# Log Martian Packets
+net.ipv4.conf.all.log_martians = 1
+net.ipv4.conf.default.log_martians = 1
+#
+# Disable TCP timestamps
+net.ipv4.tcp_timestamps = 0
+#


### PR DESCRIPTION
These changes implement many but not all of the system hardening recommendations made by Lynis and OpenVAS.  Some recommendations such as disabling root login and using an admin account with sudo will probably never be implemented. Others such as changing the default umask from 022 to 027 might lead to problems in certain appliances where scripts assume the default values.  I tried to make the sysctl variables easy to override either in /etc/sysctl.conf or by any file beginning with a number greater than 10 in /etc/sysctl.d/.
One thing to remember is that in a container (LXC or LXD), certain sysctl variables are read-only in the container and cannot be overridden by these settings. In this case, the variables must be overridden in the container host.  Depending on the host, hardware, VM, AWS, etc. it may not be possible to achieve a perfect Lynis score, and this is perfectly acceptable.