### PR TITLE
Removed update-motd (use pam instead)

### DIFF
--- a/overlays/turnkey.d/update-motd/etc/cron.d/update-motd
+++ b/overlays/turnkey.d/update-motd/etc/cron.d/update-motd
@@ -1,4 +1,0 @@
-# cron job for updating motd
-*/10 * * * * root run-parts /etc/update-motd.d > /etc/motd
-
-


### PR DESCRIPTION
Essentially reverts https://github.com/turnkeylinux/common/commit/da74f785b00b5586a7769791b8e1fc8d5feb4f32 as previous motd issues have been resolved in stretch. Closes https://github.com/turnkeylinux/tracker/issues/1059