### PR TITLE
Replace the outdated .bashrc prompt code with a bash4 shell setting

### DIFF
--- a/overlays/turnkey.d/bashrc/etc/skel/.bashrc
+++ b/overlays/turnkey.d/bashrc/etc/skel/.bashrc
@@ -28,50 +28,8 @@ if [ -z "$debian_chroot" ] && [ -r /etc/debian_chroot ]; then
     debian_chroot=$(cat /etc/debian_chroot)
 fi
 
-function realpath()
-{
-    f=$@
-
-    if [ -d "$f" ]; then
-        base=""
-        dir="$f"
-    else
-        base="/$(basename "$f")"
-        dir=$(dirname "$f")
-    fi
-
-    dir=$(cd "$dir" && /bin/pwd)
-
-    echo "$dir$base"
-}
-
-# Set prompt path to max 2 levels for best compromise of readability and usefulness
-promptpath () {
-    realpwd=$(realpath $PWD)
-    realhome=$(realpath $HOME)
-
-    # if we are in the home directory
-    if echo $realpwd | grep -q "^$realhome"; then
-        path=$(echo $realpwd | sed "s|^$realhome|\~|")
-        if [ "$path" = "~" ] || [ "$(dirname "$path")" = "~" ]; then
-            echo $path
-        else
-            echo $(basename $(dirname "$path"))/$(basename "$path")
-        fi
-        return
-    fi
-
-    path_dir=$(dirname "$PWD")
-    # if our parent dir is a top-level directory, don't mangle it
-    if [ $(dirname "$path_dir") = "/" ]; then
-        echo $PWD
-    else
-        path_parent=$(basename "$path_dir")
-        path_base=$(basename "$PWD")
-
-        echo $path_parent/$path_base
-    fi
-}
+# shorten current working directory to 2 last components in prompt
+PROMPT_DIRTRIM=2
 
 # If this is an xterm set the title to user@host:dir
 case "$TERM" in
@@ -93,13 +51,13 @@ if [ "$TERM" != "dumb" ]; then
     alias egrep='egrep --color=auto'
 
     # Set a terminal prompt style (default is fancy color prompt)
-    PS1='${debian_chroot:+($debian_chroot)}\[\033[01;33m\]\u@\h \[\033[01;34m\]$(promptpath)\[\033[00m\]\$ '
+    PS1='${debian_chroot:+($debian_chroot)}\[\033[01;33m\]\u@\h \[\033[01;34m\]\w\[\033[00m\]\$ '
 else
     alias ls="ls -F"
     alias ll='ls -alF'
     alias la='ls -A'
     alias l='ls -CF'
-    PS1='${debian_chroot:+($debian_chroot)}\u@\h $(promptpath)\$ '
+    PS1='${debian_chroot:+($debian_chroot)}\u@\h \w\$ '
 fi
 
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
I ran into this when investigating https://github.com/turnkeylinux/tracker/issues/1094 and noticed that the code is 7 years old and gets in the way sometimes.