### PR TITLE
Removed some deprecated packages from nodejs conf script

### DIFF
--- a/conf/nodejs
+++ b/conf/nodejs
@@ -1,5 +1,5 @@
 #!/bin/bash -ex
-GLOBALS='bower grunt grunt-cli nsp'
+GLOBALS='grunt grunt-cli'
 
 for package in $GLOBALS; do
 	npm install -g $package


### PR DESCRIPTION
Notes on package removals:

NSP's functionality has been merged into npm (see https://blog.npmjs.org/post/175511531085/the-node-security-platform-service-is-shutting)

Bower has been deprecated and referenced in a banner on the bower website (https://bower.io/) and presumably in other places, suggested alternatives include webpack and yarn, I know nothing about these packages and can't offer any suggestion moving forward regarding a bower replacement.