### PR TITLE
Add systemctl shim script to common.

### DIFF
--- a/overlays/turnkey.d/systemd-chroot/usr/local/bin/systemctl
+++ b/overlays/turnkey.d/systemd-chroot/usr/local/bin/systemctl
@@ -1,0 +1,47 @@
+#!/bin/bash -e
+
+# Temporary TKLDev build time systemctl wrapper.
+#
+# Only passes enable|disable as other actions will fail.
+
+fatal() { echo "FATAL [$0]: $@" 1>&2; exit 1; }
+warning() { echo "WARNING [$0]: $@"; }
+
+_start_stop() {
+    exit_code=0
+
+    # try service first; note this is also wrapped; see /usl/local/bin/service
+    service $2 $1 || exit_code=$?
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        return
+    else
+        # check if an init.d script exists
+        initd=/etc/init.d/$2
+        if [[ -f "$initd" ]]; then
+            $initd $1 || fatal "$initd $1 returned a non-zero exit code."
+        else
+            fatal "Unable to $1 service: $2 (tried 'service $2 $1', and $initd doesn't exist)."
+        fi
+    fi
+}
+
+[[ "$#" -eq 2 ]] || fatal "2 arguments required (given '$@')."
+
+case in $1
+    start)
+        _start_stop start $2;;
+
+    stop)
+        _start_stop stop $2;;
+
+    restart|reload)
+        _stop $2
+        _start $2;;
+
+    enable|disable)
+        /usr/bin/systemctl $1 $2;;
+
+    *)
+        fatal "Unknown command '$1'"
+esac

--- a/removelists-final/turnkey
+++ b/removelists-final/turnkey
@@ -1,5 +1,6 @@
 # rm composer auth token
 /root/.composer/auth.json
 
-# rm systemd not working in chroot workaround
+# rm common systemctl chroot workaround(s)
 /usr/local/bin/service
+/usr/local/bin/systemctl


### PR DESCRIPTION
An extension to the existing `/usr/localbin/system` script already provided via the common TurnKey overlay. This provides a `systemctl` wrapper/shim.