### PR TITLE
Fix lighttpd warning

### DIFF
--- a/overlays/adminer/etc/adminer/lighttpd.conf
+++ b/overlays/adminer/etc/adminer/lighttpd.conf
@@ -16,7 +16,4 @@ $SERVER["socket"] == ":12322" {
     alias.url = ( "/adminer/" => "/usr/share/adminer/adminer/" )
     alias.url += ( "/adminer-editor/" => "/usr/share/adminer/editor/" )
     alias.url += ( "/externals/" => "/usr/share/adminer/externals/" )
-
-    # Set Error/Log
-    server.errorlog = "/var/log/lighttpd/adminer.error.log"
 }


### PR DESCRIPTION
Fixes a warning in lighttpd, server.errorlog is only valid in the global context, not per-site configuration and lighttpd will only log to 1 file. This has infact always been the case however now it produces a warning, which this PR solves.