### PR TITLE
test for existence of 'a2enmod' rather than execute it blind

### DIFF
--- a/conf/adminer-apache
+++ b/conf/adminer-apache
@@ -1,8 +1,12 @@
 #!/bin/sh -e
 
-echo Listen 12322 >> /etc/apache2/ports.conf
-ln -s /etc/adminer/apache.conf /etc/apache2/sites-available/adminer.conf
-a2ensite adminer
+FILE=/etc/apache2/ports.conf
+BIN=/usr/sbin/a2ensite
+if [ -f "$FILE" -a -x "$BIN" ]; then
+    echo Listen 12322 >> /etc/apache2/ports.conf
+    ln -s /etc/adminer/apache.conf /etc/apache2/sites-available/adminer.conf
+    a2ensite adminer
+fi
 
 # add mcrypt support to apache2 (if not already configured)
 #debconf-set-selections << END

--- a/conf/apache-cgi
+++ b/conf/apache-cgi
@@ -2,4 +2,6 @@
 OLD=usr/lib/cgi-bin
 NEW=var/www/cgi-bin
 FILE=/etc/apache2/conf-available/serve-cgi-bin.conf
-sed -i "s|$OLD|$NEW|g" $FILE
+if [ -f "$FILE" ]; then
+    sed -i "s|$OLD|$NEW|g" $FILE
+fi

--- a/conf/apache-vhost
+++ b/conf/apache-vhost
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
 # each site is defined on its own, this removes the warnings
-sed -i "s|^NameVirtualHost \(.*\)||" /etc/apache2/ports.conf
-
+CONF="/etc/apache2/ports.conf"
+if [ -f "$CONF" ]; then
+    sed -i "s|^NameVirtualHost \(.*\)||" $CONF
+fi

--- a/conf/turnkey.d/zz-ssl-ciphers
+++ b/conf/turnkey.d/zz-ssl-ciphers
@@ -3,7 +3,7 @@
 # zz-ssl-ciphers
 #
 # This script was instigated by John Carver 
-# It provides a common set of hardened SSL/TLS ciphers fo all webserver apps
+# It provides a common set of hardened SSL/TLS ciphers for all webserver apps
 # Base configuration is provided by relevant overlay files
 
 set ${CERTFILE:="/etc/ssl/private/cert.pem"}
@@ -26,7 +26,8 @@ fatal() {
 
 # Apache2
 CONF="/etc/apache2/mods-available/ssl.conf"
-if [ -f "$CONF" ]; then
+BIN="/usr/sbin/a2enmod"
+if [ -f "$CONF" -a -x "$BIN" ]; then
     sed -i "s|^\(\s*SSLCipherSuite\s\+\).*$|\1${SECURE_CIPHER_LIST}|g" $CONF    
     a2enmod ssl
     a2enconf security


### PR DESCRIPTION
In the case that leftover apache debris exists in /etc for some reason, this change improves robustness of this particular script.