### PR TITLE
Some refactoring of gh_releases

### DIFF
--- a/overlays/github-latest-release/usr/local/bin/gh_releases
+++ b/overlays/github-latest-release/usr/local/bin/gh_releases
@@ -7,15 +7,18 @@ tmp_dir=/tmp/gh_releases
 rm -rf $tmp_dir
 mkdir -p $tmp_dir
 
-fatal() {
-    echo -e "\n[FATAL] $1" 1>&2
-    exit 1
-}
+fatal() { echo -e "\n[FATAL] $@" 1>&2; exit 1; }
+warning() { echo -e "[WARNING] $@" 1>&2; }
+
 usage() {
-    echo "Usage: gh_releases.sh <user>/<repo>" 1>&2
-    echo "Note: requires GITHUB_USER and GITHUB_USER_TOKEN" 1>&2
-    echo "      environment variables to be set." 1>&2
-    echo "For debugging, set DEBUG=y." 1>&2
+    cat >&2 <<EOF
+Usage: $(basename $0) <user>/<repo>
+
+Note: Setting GITHUB_USER and GITHUB_USER_TOKEN environment variables are
+      recommended. If not set, multipage results may be unreliable.
+
+      For debugging, set DEBUG=y.
+EOF
 }
 
 if [[ -z "$repo_path" ]]; then
@@ -23,22 +26,26 @@ if [[ -z "$repo_path" ]]; then
     fatal "user/repo not provided!"
 fi
 if [[ -z "$GITHUB_USER" ]]; then
-    usage
-    fatal "GITHUB_USER not set!"
+    warn="GITHUB_USER not set!"
 fi
 if [[ -z "$GITHUB_USER_TOKEN" ]]; then
-    usage
-    fatal "GITHUB_USER_TOKEN not set!"
+    warn="$warn GITHUB_USER_TOKEN not set!"
+fi
+if [[ -n "$GITHUB_USER" ]] && [[ -n "$GITHUB_USER_TOKEN" ]]; then
+    USER="-u $GITHUB_USER:$GITHUB_USER_TOKEN"
+else
+    warning $warn "Authentication won't be used."
+    USER=""
 fi
 
-echo -n "Fetching releases from github for \"$repo_path\"... " 1>&2
+echo -n "Fetching releases from github for '$repo_path'... " 1>&2
 
 get_page() {
     url=$1
     key=$2
     page=$3
     tmp_file=$(mktemp $tmp_dir/XXXX.tmp)
-    curl -u "$GITHUB_USER:$GITHUB_USER_TOKEN" -b /tmp/cookies.txt -c /tmp/cookies.txt -s "${url}?page=${page}&per_page=100" > $tmp_file || true
+    curl $USER -b /tmp/cookies.txt -c /tmp/cookies.txt -s "${url}?page=${page}&per_page=100" > $tmp_file || true
     if grep "Bad credentials" $tmp_file >/dev/null ; then
         fatal "Bad GitHub credentials"
     else
@@ -52,7 +59,6 @@ get_all_pages() {
     key=$2
     declare -i page=0
     last_page="$(get_page "$url" "$key" "$page")"
-    touch /tmp/gh_releases
 
     while [[ -n "$last_page" ]]
     do
@@ -62,11 +68,9 @@ get_all_pages() {
     done
 }
 
-
 get_all_pages "https://api.github.com/repos/${repo_path}/releases" "tag_name"
 get_all_pages "https://api.github.com/repos/${repo_path}/tags" "name"
 
 echo "Done!" 1>&2
 cat $tmp_dir/releases | sort --version-sort --unique
 [[ -z $DEBUG ]] && rm -rf $tmp_dir
-


### PR DESCRIPTION
Primarily the changes are to support unauthenticated usage. But some other tweaks too.

Note: under some circumstances (e.g. multipage results) unathenticated usage may lead to errors and/or unreliable results. So is generally not recommended in production...

FWIW the core of this has been sitting in my local dev common for some time. This is just a commit of what I've been using locally for a while, with a few more tweaks...