### PR TITLE
Rails plan tweak

### DIFF
--- a/plans/turnkey/rails
+++ b/plans/turnkey/rails
@@ -1,9 +1,8 @@
+#include <turnkey/mysql>
+
 apache2
 webmin-apache
 apache2-dev
-
-default-mysql-server
-webmin-mysql
 
 build-essential             /* needed to build gems */
 libgmp-dev                  /* real package behind virtual libgmp10-dev which is required */

--- a/plans/turnkey/rails
+++ b/plans/turnkey/rails
@@ -5,19 +5,17 @@ apache2-dev
 default-mysql-server
 webmin-mysql
 
-build-essential            /* needed to build gems */
-libgmp-dev		   /* real package behind virtual libgmp10-dev which is required */
-default-libmysqlclient-dev /* needed to build mysql gem */
-libcurl4-openssl-dev       /* needed to build passenger apache2 module */
-libreadline-gplv2-dev      /* needed for rails console */
+build-essential             /* needed to build gems */
+libgmp-dev                  /* real package behind virtual libgmp10-dev which is required */
+default-libmysqlclient-dev  /* needed to build mysql gem */
+libcurl4-openssl-dev        /* needed to build passenger apache2 module */
+libreadline-gplv2-dev       /* needed for rails console */
 
+libapr1-dev                 /* needed to build passenger gem */
+libaprutil1-dev             /* needed to build passenger gem */
+libssl-dev                  /* needed to build passenger gem */
 
-libapr1-dev                /* needed to build passenger gem */
-libaprutil1-dev            /* needed to build passenger gem */
-libssl-dev                 /* needed to build passenger gem */
-
-libxml2-dev                /* common dep for gem building, e.g., sanitize */
-libxslt1-dev               /* common dep for gem building, e.g., sanitize */
+libxml2-dev                 /* common dep for gem building, e.g., sanitize */
+libxslt1-dev                /* common dep for gem building, e.g., sanitize */
 
 nodejs
-


### PR DESCRIPTION
Fairly minor tweak to the `rails` plan.

Most of the changes are just cosmetic stuff (aligning comments and removing trailing newline).

Although I have removed the MySQL related packages and included the [`mysql` plan](https://github.com/turnkeylinux/common/blob/master/plans/turnkey/mysql). Note this now means that `python3-pymysql` is included by default (required as it's used by all mysql inithooks).

Related to https://github.com/turnkeylinux-apps/redmine/pull/20

----

I was also thinking that there might also be value in moving lots of these packages to a `rails-common` plan (or renaming this one `rails-mysql`) so that the packages common to both this plan and `rails-pgsql` would only need to be stored in one place. However, currently only Canvas uses `rails-pgsql`, so whilst it might tidy things a bit and remove a small amount of duplication, I'm not sure how much real value it would add. Also, I note that there are a few packages that don't quite match. I'm not sure whether that's because of different dependencies, or we're shipping some unrequired stuff, or what might be going on...