### PR TITLE
Refactor secupdates (cronapt) to never remove apps

### DIFF
--- a/conf/turnkey.d/cronapt
+++ b/conf/turnkey.d/cronapt
@@ -1,8 +1,12 @@
-#!/bin/sh -e
+#!/bin/bash -e
+
+# Note that a Confconsole plugin that allows the user to select between these
+# profiles is included as overlays/turnkey.d/cronapt-confconsole
 
 [ -e /etc/cron-apt ] || exit 0
 
 cd /etc/cron-apt
+mkdir -p action-available.d
 
 cat >> config << EOF
 MAILON="never"
@@ -11,9 +15,52 @@ EOF
 
 echo -n > action.d/3-download
 
-cat > action.d/5-install << EOF
-autoclean -q -y
-upgrade -q -y \
+cat > action.d/5-install.README << EOF
+# These files named '5-install.XXX' relate to the '5-install' cronapt script
+# located in /etc/cron-apt/actions.d/
+#
+# Which particular config.d file to be applied is determined by what the
+# symlink /etc/cron-apt/config.d/5-install points to.
+#
+#
+# 5-install.1 aka 'default'
+# -------------------------
+#
+# This is the historic and default TurnKey cron-apt behaviour. Only packages
+# from the security.sources.list repositories will be installed. Any conflicts
+# or missing dependencies will not be installed and will cause package removal.
+# This package removal may cause one or more services to fail.
+#
+# 5-install.2 aka 'alternate'
+# ---------------------------
+#
+# This is a new option which is similar to the default. However, it will not
+# allow removal of packages. This will maximise uptime of all services, but
+# conversely, may also allow services with unpatched security vulnerabilities
+# to continue running.
+EOF
+
+cat > action-available.d/5-install.1 << EOF
+autoclean -y
+
+# cron-apt updates as per historical and current TurnKey default
+# Please see 5-install.README for details
+
+dist-upgrade -y \
+    -o APT::Get::Show-Upgraded=true \
+    -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/security.sources.list \
+    -o Dir::Etc::sourceparts=nonexistent \
+    -o DPkg::Options::=--force-confdef \
+    -o DPkg::Options::=--force-confold
+EOF
+
+cat > action-available.d/5-install.2 << EOF
+autoclean -y
+
+# cron-apt will not allow removal of pkgs
+# Please see 5-install.README for details
+
+upgrade -y \
     -o APT::Get::Upgrade-Allow-New=true \
     -o APT::Get::Show-Upgraded=true \
     -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/security.sources.list \
@@ -21,3 +68,6 @@ upgrade -q -y \
     -o DPkg::Options::=--force-confdef \
     -o DPkg::Options::=--force-confold
 EOF
+
+# Enable original config as default
+ln -sf ../action-available.d/5-install.1 action.d/5-install

--- a/conf/turnkey.d/cronapt
+++ b/conf/turnkey.d/cronapt
@@ -10,8 +10,14 @@ SYSLOGON="output"
 EOF
 
 echo -n > action.d/3-download
+
 cat > action.d/5-install << EOF
 autoclean -q -y
-dist-upgrade -q -y -o APT::Get::Show-Upgraded=true -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/security.sources.list -o Dir::Etc::sourceparts=nonexistent -o DPkg::Options::=--force-confdef -o DPkg::Options::=--force-confold
+upgrade -q -y \
+    -o APT::Get::Upgrade-Allow-New=true \
+    -o APT::Get::Show-Upgraded=true \
+    -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/security.sources.list \
+    -o Dir::Etc::sourceparts=nonexistent \
+    -o DPkg::Options::=--force-confdef \
+    -o DPkg::Options::=--force-confold
 EOF
-

--- a/overlays/turnkey.d/cronapt-confconsole/usr/lib/confconsole/plugins.d/System_Settings/Secupdates_adv_conf.py
+++ b/overlays/turnkey.d/cronapt-confconsole/usr/lib/confconsole/plugins.d/System_Settings/Secupdates_adv_conf.py
@@ -1,0 +1,106 @@
+"""Config SecUpdate behaviour"""
+
+from pathlib import Path
+from typing import List, Tuple, Union
+
+FILE_PATH = Path('/etc/cron-apt/action.d/5-install')
+CONF_DEFAULT = Path('/etc/cron-apt/config.d/5-install.1')
+CONF_ALT = Path('/etc/cron-apt/config.d/5-install.2')
+
+doc_url = 'www.turnkeylinux.org/docs/auto-secupdates#issue-res'
+
+info_default = """
+This is the historic and default TurnKey cronapt behaviour. Only packages \
+from the repos listed in security.sources.list will be installed. \
+Missing dependencies will not be installed and will cause package removal. \
+This package removal may cause one or more services to fail."""
+
+info_alternate = """
+This is a new option which is similar to the default. However, it will not \
+allow removal of packages. This will maximise uptime of all services, but \
+conversely, may also allow services with unpatched security vulnerabilities \
+to continue running."""
+
+def new_link(link_path: Path, target_path: Path) -> None:
+    try:
+        link_path.unlink()
+    except FileNotFoundError:
+        pass
+    link_path.symlink_to(target_path)
+
+
+def conf_default() -> None:
+    new_link(FILE_PATH, CONF_DEFAULT)
+
+
+def conf_alternate() -> None:
+    new_link(FILE_PATH, CONF_ALT)
+
+
+def check_paths() -> Tuple[int, Union[List, str]]:
+    errors = []
+    for _path in [FILE_PATH, CONF_DEFAULT, CONF_ALT]:
+        if not _path.exists():
+            errors.append('Path not found: {}'.format(str(_path)))
+    if errors:
+        return 2, errors
+    if FILE_PATH.is_symlink():
+        _target_path = FILE_PATH.resolve()
+        if _target_path == CONF_DEFAULT:
+            return 0, 'default'
+        elif _target_path == CONF_ALT:
+            return 0, 'alternate'
+        else:
+            return 1, ['Unexpected link target: {}'.format(str(_target_path))]
+    else:
+        return 1, ['{} is not a symlink'.format(str(FILE_PATH))]
+
+
+def button_label(current: str) -> str:
+    options = ['default', 'alternate']
+    try:
+        options.remove(current)
+    except ValueError:
+        pass
+    
+    other = options[0]
+    msg = f"Enable '{other}'"
+
+    return f"{msg:^20}"
+
+def get_details(choice: str) -> Union[str, None]:
+    if choice == 'default':
+        return info_default
+    elif choice == 'alternate':
+        return info_alternate
+    else:
+        return None
+
+def run() -> None:
+    retcode, data = check_paths()
+    if retcode:
+        msg = ('Error(s) encountered while checking status:')
+        for message in data:
+            msg = f'{msg}\n\t{message}'
+        msg = (f'{msg}\nFor more info please see\n\n{doc_url}')
+        r = console.msgbox('Error', msg)
+    else:
+        msg = ('Current SecUpate Issue resolution strategy is:\n\n\t{}'
+               '\n{}\n\nFor more info please see\n\n{}')
+        r = console._wrapper('yesno',
+                             msg.format(data, get_details(data), doc_url),
+                             20, 60,
+                             yes_label=button_label(data),
+                             no_label='Back')
+        while r == 'ok':
+            # Toggle was clicked
+            if data == 'default':
+                conf_alternate()
+            else:
+                conf_default()
+            retcode, data = check_paths()
+            r = console._wrapper('yesno',
+                                 msg.format(data, get_details(data), doc_url),
+                                 20, 60,
+                                 yes_label=button_label(data),
+                                 no_label='Back')

--- a/overlays/turnkey.d/cronapt-confconsole/usr/lib/confconsole/plugins.d/System_Settings/Secupdates_adv_conf.py
+++ b/overlays/turnkey.d/cronapt-confconsole/usr/lib/confconsole/plugins.d/System_Settings/Secupdates_adv_conf.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from typing import List, Tuple, Union
 
 FILE_PATH = Path('/etc/cron-apt/action.d/5-install')
-CONF_DEFAULT = Path('/etc/cron-apt/config.d/5-install.1')
-CONF_ALT = Path('/etc/cron-apt/config.d/5-install.2')
+CONF_DEFAULT = Path('/etc/cron-apt/action-available.d/5-install.1')
+CONF_ALT = Path('/etc/cron-apt/action-available.d/5-install.2')
 
 doc_url = 'www.turnkeylinux.org/docs/auto-secupdates#issue-res'
 


### PR DESCRIPTION
Closes https://github.com/turnkeylinux/tracker/issues/1536

Use 'upgrade' with APT::Get::Upgrade-Allow-New=true, rather than
'dist-upgrade' (allows new packages to be installed, but never removes
any).

Also improved layout for easier reading.