### PR TITLE
minor tweaks to cron-apt changes

### DIFF
--- a/conf/turnkey.d/cronapt
+++ b/conf/turnkey.d/cronapt
@@ -15,13 +15,21 @@ EOF
 
 echo -n > action.d/3-download
 
-cat > action.d/5-install.README << EOF
-# These files named '5-install.XXX' relate to the '5-install' cronapt script
-# located in /etc/cron-apt/actions.d/
+cat > TurnKey_Linux_5-install.README << EOF
+# The files in actiona-available.d named '5-install.XXX' relate to the
+# '5-install' cronapt script located in /etc/cron-apt/actions.d/
 #
-# Which particular config.d file to be applied is determined by what the
+# Which particular action to be applied is determined by which file the
 # symlink /etc/cron-apt/config.d/5-install points to.
 #
+# To double check this; use this::
+#
+#       ls -l /etc/cron-apt/action.d/5-install
+#
+# E.g. here is the expected output under default condition (only important
+# part shown)::
+#
+#       /etc/cron-apt/action.d/5-install -> ../action-available.d/5-install.default
 #
 # 5-install.default aka 'default'
 # -------------------------------

--- a/conf/turnkey.d/cronapt
+++ b/conf/turnkey.d/cronapt
@@ -16,7 +16,7 @@ EOF
 echo -n > action.d/3-download
 
 cat > TurnKey_Linux_5-install.README << EOF
-# The files in actiona-available.d named '5-install.XXX' relate to the
+# The files in action-available.d named '5-install.XXX' relate to the
 # '5-install' cronapt script located in /etc/cron-apt/actions.d/
 #
 # Which particular action to be applied is determined by which file the

--- a/conf/turnkey.d/cronapt
+++ b/conf/turnkey.d/cronapt
@@ -23,16 +23,16 @@ cat > action.d/5-install.README << EOF
 # symlink /etc/cron-apt/config.d/5-install points to.
 #
 #
-# 5-install.1 aka 'default'
-# -------------------------
+# 5-install.default aka 'default'
+# -------------------------------
 #
 # This is the historic and default TurnKey cron-apt behaviour. Only packages
 # from the security.sources.list repositories will be installed. Any conflicts
 # or missing dependencies will not be installed and will cause package removal.
 # This package removal may cause one or more services to fail.
 #
-# 5-install.2 aka 'alternate'
-# ---------------------------
+# 5-install.alt aka 'alternate'
+# -----------------------------
 #
 # This is a new option which is similar to the default. However, it will not
 # allow removal of packages. This will maximise uptime of all services, but
@@ -40,12 +40,8 @@ cat > action.d/5-install.README << EOF
 # to continue running.
 EOF
 
-cat > action-available.d/5-install.1 << EOF
+cat > action-available.d/5-install.default << EOF
 autoclean -y
-
-# cron-apt updates as per historical and current TurnKey default
-# Please see 5-install.README for details
-
 dist-upgrade -y \
     -o APT::Get::Show-Upgraded=true \
     -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/security.sources.list \
@@ -54,12 +50,8 @@ dist-upgrade -y \
     -o DPkg::Options::=--force-confold
 EOF
 
-cat > action-available.d/5-install.2 << EOF
+cat > action-available.d/5-install.alt << EOF
 autoclean -y
-
-# cron-apt will not allow removal of pkgs
-# Please see 5-install.README for details
-
 upgrade -y \
     -o APT::Get::Upgrade-Allow-New=true \
     -o APT::Get::Show-Upgraded=true \
@@ -70,4 +62,4 @@ upgrade -y \
 EOF
 
 # Enable original config as default
-ln -sf ../action-available.d/5-install.1 action.d/5-install
+ln -sf ../action-available.d/5-install.default action.d/5-install

--- a/overlays/turnkey.d/cronapt-confconsole/usr/lib/confconsole/plugins.d/System_Settings/Secupdates_adv_conf.py
+++ b/overlays/turnkey.d/cronapt-confconsole/usr/lib/confconsole/plugins.d/System_Settings/Secupdates_adv_conf.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from typing import List, Tuple, Union
 
 FILE_PATH = Path('/etc/cron-apt/action.d/5-install')
-CONF_DEFAULT = Path('/etc/cron-apt/action-available.d/5-install.1')
-CONF_ALT = Path('/etc/cron-apt/action-available.d/5-install.2')
+CONF_DEFAULT = Path('/etc/cron-apt/action-available.d/5-install.default')
+CONF_ALT = Path('/etc/cron-apt/action-available.d/5-install.alt')
 
 doc_url = 'www.turnkeylinux.org/docs/auto-secupdates#issue-res'
 


### PR DESCRIPTION
Move the readme from `/etc/cron-apt/action.d/5-install.README` to `/etc/cron-apt/TurnKey_Linux_5-install.README` - eliminates noise when running `cron-apt` (it appears that all files in `/etc/cron-apt/action.d/` are parsed).

Also, remove comments from cron-apt `action-available.d` files - again the comments are not understood as comments when parsed and causes polluted output.

Also renamed the `action-available.d` files - made their names explicit.