### PR TITLE
Confconsole perf and info schema install

### DIFF
--- a/conf/adminer-mysql
+++ b/conf/adminer-mysql
@@ -23,7 +23,7 @@ sed -i '/^.*\$tkl_database/ s|DRIVER|server|' $TKL_INDEX
 # Create root-like adminer MySQL user account
 service mysql start
 ADMIN_PWORD=$(mcookie)
-mysql -u root -e <<EOF
+mysql <<EOF
 USE mysql;
 GRANT ALL PRIVILEGES ON *.* to 'adminer'@localhost IDENTIFIED BY '$ADMIN_PWORD' WITH GRANT OPTION;
 EOF

--- a/conf/adminer-mysql
+++ b/conf/adminer-mysql
@@ -23,9 +23,9 @@ sed -i '/^.*\$tkl_database/ s|DRIVER|server|' $TKL_INDEX
 # Create root-like adminer MySQL user account
 service mysql start
 ADMIN_PWORD=$(mcookie)
-mysql <<EOF
+mysql -u root -e <<EOF
 USE mysql;
-GRANT ALL ON *.* to 'adminer'@localhost IDENTIFIED BY '$ADMIN_PWORD' WITH GRANT OPTION;
+GRANT ALL PRIVILEGES ON *.* to 'adminer'@localhost IDENTIFIED BY '$ADMIN_PWORD' WITH GRANT OPTION;
 EOF
 service mysql stop
 

--- a/overlays/mysql/usr/lib/confconsole/plugins.d/System_Settings/Mysql_perf_info.py
+++ b/overlays/mysql/usr/lib/confconsole/plugins.d/System_Settings/Mysql_perf_info.py
@@ -1,0 +1,22 @@
+'''Install MySQL Perf & Info Schemas'''
+from subprocess import check_call, CalledProcessError
+
+def run():
+    msg = ('Install and enable MySQL/MariaDB Performance and Information'
+           ' SysSchemas.'
+           '\n\nRun this to install and enable a range of views, functions and'
+           ' procedures to help MariaDB administrators get insight in to'
+           ' MariaDB Database usage and aid performance tuning.'
+           '\n\nOnce installed it can not be (easily) removed, but can be'
+           ' disabled if need be.'
+           '\n\nFor further info, please see'
+           ' https://github.com/FromDual/mariadb-sys')
+    r = console._wrapper('yesno', msg, 20, 60,
+                             yes_label='Install',
+                             no_label='Back')
+    if r == 'ok':
+        try:
+            output = check_call(['turnkey-mysql-install-perf-info-schemas',
+                                 'install'])
+        except CalledProcessError:
+            console.msgbox('Error', 'There was an error trying to install.')

--- a/overlays/mysql/usr/local/bin/turnkey-mysql-install-perf-info-schemas
+++ b/overlays/mysql/usr/local/bin/turnkey-mysql-install-perf-info-schemas
@@ -1,0 +1,75 @@
+#!/bin/bash -e
+
+fatal() { echo "FATAL: $@"; exit 1; }
+info() { echo "INFO: $@"; }
+
+usage() {
+    if [[ $# -gt 0 ]]; then
+        echo "ERROR: $@"
+        echo
+        exit_code=1
+    fi
+    cat << EOF
+$(basename $0) install|help [-h|--help]
+
+Arguments::
+
+    install     Install MariaDB Performance schema and Sysschema.
+    help        Show this help and exit.
+
+    -h|--help   As per 'help' (above).
+
+Environment variables::
+
+    DEBUG       Set to enable debug output.
+
+EOF
+    exit $exit_code
+}
+
+[[ -z "$DEBUG" ]] || set -x
+
+user=$(whoami)
+[[ "$(whoami)" == 'root' ]] || fatal "Must be run by root; please re-run with 'sudo'."
+
+[[ $# -ne 0 ]] || usage "Must have one argument."
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        install)
+            shift
+            continue;;
+        -h|--help|help)
+            usage;;
+        *)
+            usage "Unknown argument $1.";;
+    esac
+done
+
+exit_code=0
+SRC=/usr/local/src
+
+cat > /etc/mysql/conf.d/performance_schema.cnf <<EOF
+# Performance schema and Sysschema for MariaDB
+# Pre-installed by TurnKey.
+[mysqld]
+performance_schema = on
+EOF
+
+cd $SRC
+curl "https://codeload.github.com/FromDual/mariadb-sys/zip/master" > mariadb-sys.zip
+
+unzip mariadb-sys.zip
+cd mariadb-sys-master/
+
+mysql -u root < ./sys_10.sql || exit_code=$?
+mysql -u root -e "set global innodb_stats_on_metadata = 0;"
+
+if [[ $exit_code -ne 0 ]]; then
+    fatal "Error importing MariaDB Performance schema and Sysschema data; rolling back." >&2
+    rm -rf /etc/mysql/conf.d/performance_schema.cnf
+else
+    info "Success importing MariaDB Performance schema and Sysschema data; restarting MariaDB."
+    systemctl restart mysql
+fi
+
+[[ -n "DEBUG" ]] || rm -rf /usr/loca/src/mariadb-sys*


### PR DESCRIPTION
Implements the Performance and information schemas, tools, etc; inc SysSchema to MariaDB.

Closes https://github.com/turnkeylinux/tracker/issues/1429