### PR TITLE
Include composer wrapper (turnkey-composer) in common

### DIFF
--- a/overlays/composer/usr/local/bin/turnkey-composer
+++ b/overlays/composer/usr/local/bin/turnkey-composer
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+[[ -z "$DEBUG" ]] || set -x
+
+COMPOSER_USER="${COMPOSER_USER:-www-data}"
+COMPOSER_USER_HOME=$(getent passwd $COMPOSER_USER | cut -d: -f6) || true
+
+if [[ -n "$COMPOSER_USER" ]] && [[ -n "$COMPOSER_USER_HOME"  ]]; then
+    COMPOSER_HOME="${COMPOSER_HOME:-$COMPOSER_USER_HOME/.composer}"
+fi
+
+COMMAND="composer $@"
+
+runuser $COMPOSER_USER -s /bin/bash -c "$COMMAND"


### PR DESCRIPTION
This will now be included in all LAMP/LAPP based appliances, plus any appliance that includes `composer.mk` or the `composer` common overlay.

Part of the solution to https://github.com/turnkeylinux/tracker/issues/1539.