### PR TITLE
Rather than comment out eth1; instead configure it as 'hotplug'.

### DIFF
--- a/overlays/turnkey.d/interfaces/etc/network/interfaces
+++ b/overlays/turnkey.d/interfaces/etc/network/interfaces
@@ -7,6 +7,6 @@ iface lo inet loopback
 auto eth0
 iface eth0 inet dhcp
 
-#auto eth1
-#iface eth1 inet dhcp
+allow-hotplug eth1
+iface eth1 inet dhcp
 


### PR DESCRIPTION
Closes https://github.com/turnkeylinux/tracker/issues/1492.