### PR TITLE
Install qemu-guest-agent by default.

### DIFF
--- a/plans/turnkey/base
+++ b/plans/turnkey/base
@@ -84,6 +84,8 @@ bsd-mailx
 postfix
 webmin-postfix
 
+qemu-guest-agent        /* QEMU/KVM guest tools - as requested in #1356 */
+
 authbind                /* add-water (confconsole lets encrypt) depends */
 dehydrated              /* add-water (confconsole lets encrypt) recommends (actually depends) */
 python3-bottle          /* add-water (confconsole lets encrypt) depends */


### PR DESCRIPTION
I've ummmed and arrrred about this one for a while, but seeing as it's only ~700kb when installed, I figured what the help, let's just do it...

Closes https://github.com/turnkeylinux/tracker/issues/1356.