### PR TITLE
Remove composer from default LAMP and LAPP installs

### DIFF
--- a/mk/turnkey/lamp.mk
+++ b/mk/turnkey/lamp.mk
@@ -4,5 +4,4 @@ COMMON_OVERLAYS += apache adminer confconsole-lamp
 COMMON_CONF += apache-vhost apache-cgi adminer-apache adminer-mysql
 
 include $(FAB_PATH)/common/mk/turnkey/php.mk
-include $(FAB_PATH)/common/mk/turnkey/composer.mk
 include $(FAB_PATH)/common/mk/turnkey/mysql.mk

--- a/mk/turnkey/lapp.mk
+++ b/mk/turnkey/lapp.mk
@@ -4,5 +4,4 @@ COMMON_OVERLAYS += apache adminer confconsole-lapp
 COMMON_CONF += apache-vhost apache-cgi adminer-apache adminer-pgsql
 
 include $(FAB_PATH)/common/mk/turnkey/php.mk
-include $(FAB_PATH)/common/mk/turnkey/composer.mk
 include $(FAB_PATH)/common/mk/turnkey/pgsql.mk


### PR DESCRIPTION
Remove from common `lamp.mk` & `lapp.mk` makefiles. We'll re add it to the `Makefile` of specific apps that use it, or we deem relevant (e.g. LAMP and LAPP appliances).

Part of https://github.com/turnkeylinux/tracker/issues/1563