### PR TITLE
build time `service`/`systemctl` overlay tweaks

### DIFF
--- a/conf/turnkey.d/shellinabox
+++ b/conf/turnkey.d/shellinabox
@@ -11,9 +11,9 @@ EOF
 # TurnKey is now providing a shellinabox systemd service file.
 # First disable the current service (which is generated from the init.d script
 # via systemd-sysv integration):
-systemctl disable shellinabox
+/lib/systemd/systemd-sysv-install disable shellinabox || true
 # Then explictly enable the TurnKey provided service file:
-systemctl enable /usr/lib/systemd/system/shellinabox.service
+systemctl enable shellinabox.service || true
 
 # Stunnel TLS/SSL support for shellinabox (aka Webshell) is now configured
 # via a stunnel.conf file - see shellinabox and/or stunnel common overlays for

--- a/overlays/turnkey.d/systemd-chroot/usr/local/bin/service
+++ b/overlays/turnkey.d/systemd-chroot/usr/local/bin/service
@@ -1,16 +1,15 @@
 #!/bin/bash
 
-if [[ $1 == "apache2" ]]; then
+if [[ $1 == "apache2"* ]]; then
     if [[ $2 == "reload" ]]; then
         APACHE_STARTED_BY_SYSTEMD=y /usr/sbin/apache2ctl restart
     else
         APACHE_STARTED_BY_SYSTEMD=y /usr/sbin/apache2ctl $2
     fi
-elif [[ $1 == "mysql" ]]; then
+elif [[ $1 == "mysql"* ]] || [[ $1 == "mariadb"* ]]; then
     /etc/init.d/mysql $2
-elif [[ $1 == "zoneminder.service" ]]; then
+elif [[ $1 == "zoneminder"* ]]; then
     echo "ignoring zoneminder ..."
 else
     /usr/sbin/service $@
 fi
-

--- a/overlays/turnkey.d/systemd-chroot/usr/local/bin/service
+++ b/overlays/turnkey.d/systemd-chroot/usr/local/bin/service
@@ -10,6 +10,13 @@ elif [[ $1 == "mysql"* ]] || [[ $1 == "mariadb"* ]]; then
     /etc/init.d/mysql $2
 elif [[ $1 == "zoneminder"* ]]; then
     echo "ignoring zoneminder ..."
+elif [[ $1 == "odoo"* ]]; then
+    if [[ $2 == "stop" ]] || [[ $2 == "restart" ]]; then
+        kill -9 $(pgrep odoo)
+    fi
+    if [[ $2 == "start" ]] || [[ $2 == "restart" ]]; then
+        runuser odoo -s /bin/bash -c "/usr/bin/odoo --config /etc/odoo/odoo.conf --logfile /var/log/odoo/odoo-server.log &"
+    fi
 else
     /usr/sbin/service $@
 fi

--- a/overlays/turnkey.d/systemd-chroot/usr/local/bin/systemctl
+++ b/overlays/turnkey.d/systemd-chroot/usr/local/bin/systemctl
@@ -26,12 +26,21 @@ _start_stop() {
     fi
 }
 
-[[ "$#" -ge 2 ]] || fatal "At least 2 arguments required (given '$@')."
+_is_running() {
+    pid=$(pgrep $1)
+    if [[ -n "$pid" ]]; then
+        echo 'true'
+    else
+        echo 'false'
+    fi
+}
 
-unset COMMAND SERVICE_NAME IGNORED
+[[ "$#" -gt 1 ]] || fatal "At least 1 argument required (none given)."
+
+unset COMMAND SERVICE_NAME QUIET IGNORED
 while [[ "$#" -gt 0 ]]; do
     case $1 in
-        start|stop|restart|reload|enable|disable|mask|unmask|is-failed|is-active)
+        start|stop|restart|reload|enable|disable|mask|unmask|is-failed|is-active|daemon-reload)
             if [[ -z "$COMMAND" ]]; then
                 COMMAND=$1
                 shift
@@ -42,13 +51,17 @@ while [[ "$#" -gt 0 ]]; do
             fi;;
         status)
             fatal "Status currently not supported in a chroot.";;
+        --quiet)
+            warning "--quiet is only honored with commands is-active|is-failed."
+            QUIET=true
+            shift;;
         --*)
             IGNORED="$IGNORED $1"
             warning "Switch '$1' will be ignored."
             shift;;
         *)
             if [[ -z "$SERVICE_NAME" ]]; then
-                SERVICE_NAME=$1
+                SERVICE_NAME=${1%.service} # remove trailing '.service' if included
                 shift
             else
                 warning "Already had service name set ('$SERVICE_NAME')."
@@ -58,32 +71,48 @@ while [[ "$#" -gt 0 ]]; do
     esac
 done
 
-if [[ -n "$COMMAND" ]] && [[ -n "$SERVICE_NAME" ]]; then
+if [[ -n "$COMMAND" ]]; then
+
+    if [[ "$SERVICE_NAME" == "ghost_localhost" ]] \
+            && [[ "$COMMAND" == 'enable' ]]; then
+        SERVICE_NAME=ghost
+    fi
+
+    if [[ "$COMMAND" != "daemon-reload" ]] && [[ -z "$SERVICE_NAME" ]]; then
+        fatal "Service name required with $COMMAND"
+    fi
+
     case $COMMAND in
-        start)
-            _start_stop start $SERVICE_NAME;;
-        stop)
-            _start_stop stop $SERVICE_NAME;;
+        start|stop)
+            _start_stop $COMMAND $SERVICE_NAME;;
 
         restart|reload)
             _start_stop stop $SERVICE_NAME
             _start_stop start $SERVICE_NAME;;
 
         enable|disable)
-            /usr/bin/systemctl $COMMAND $SERVICE_NAME;;
+            /usr/bin/systemctl $COMMAND $SERVICE_NAME || exit_code=$?
+            exit $exit_code;;
 
         mask|unmask)
-            /usr/bin/systemctl $COMMAND $SERVICE_NAME;;
+            /usr/bin/systemctl $COMMAND $SERVICE_NAME || exit_code=$?
+            exit $exit_code;;
 
-        is-failed)
-            warning "Call to 'is-failed' always returns FALSE (exit code 1)."
-            echo false >2
-            exit 1;;
-
-        is-active)
-            warning "Call to 'is-active' always returns TRUE (exit code 0)."
-            echo true >2
+        daemon-reload)
+            warning "Ignoring daemon-reload, init scripts not cached."
             exit 0;;
+
+        is-failed|is-active)
+            running=$(_is_running $SERVICE_NAME)
+            if $running; then
+                [[ -n "$QUIET" ]] || echo "active"
+                [[ "$COMMAND" != "is-failed" ]] || exit 0
+                exit 1
+            else
+                [[ -n "$QUIET" ]] || echo "inactive"
+                [[ "$COMMAND" != "is-failed" ]] || exit 1
+                exit 0
+            fi;;
     esac
 else
     fatal "Command ('$COMMAND') and/or Service name ('$SERVICE_NAME') not set or not found."

--- a/overlays/turnkey.d/systemd-chroot/usr/local/bin/systemctl
+++ b/overlays/turnkey.d/systemd-chroot/usr/local/bin/systemctl
@@ -40,9 +40,11 @@ while [[ "$#" -gt 0 ]]; do
                 warning "Now setting as '$COMMAND'."
                 shift
             fi;;
+        status)
+            fatal "Status currently not supported in a chroot.";;
         --*)
             IGNORED="$IGNORED $1"
-            warning "Swtich '$1' will be ignored."
+            warning "Switch '$1' will be ignored."
             shift;;
         *)
             if [[ -z "$SERVICE_NAME" ]]; then


### PR DESCRIPTION
The changes here were initially and primarily to support the v16.1 [Odoo](https://github.com/turnkeylinux-apps/odoo) update ([see here](https://github.com/turnkeylinux-apps/odoo/pull/18)).

I have also done some refactoring and tidying up.

This PR is also aimed at allowing the `systemctl` wrapper to work with [Ghost](https://github.com/turnkeylinux-apps/ghost) (and replace the existing overlaid [Ghost specific `systemctl` wrapper](https://github.com/turnkeylinux-apps/ghost/blob/master/overlay/usr/local/bin/systemctl)). Thus it is part of https://github.com/turnkeylinux/tracker/issues/1504.

Moving forward, we can tweak these scripts to support appliances on an "as needs be" basis.

As much as possible, IMO it would be good to keep the `systemctl` wrapper relatively generic, with the `service` wrapper to deal with specific idiosyncrasies of individual apps.

FYI, if the `/usr/sbin/service` command detects that systemd isn't running (as in a chroot) then it defaults to using `/etc/init.d` scripts. Any daemons that ship with `init.d` scripts (that work in a chroot) should continue to "just work", whilst we can make specific tweaks in our `service` wrapper as needed for other specific use cases.