### PR TITLE
Remove old redundant MySQL/MariaDB 'force_utf8.cnf' file.

### DIFF
--- a/overlays/mysql/etc/mysql/conf.d/force_utf8.cnf
+++ b/overlays/mysql/etc/mysql/conf.d/force_utf8.cnf
@@ -1,8 +1,0 @@
-# Force Unicode/UTF8
-[mysqld]
-init_connect='SET collation_connection = utf8_general_ci'
-init_connect='SET collation_database = utf8_general_ci'
-init_connect='SET NAMES utf8'
-character-set-server=utf8
-collation-server=utf8_general_ci
-skip-character-set-client-handshake


### PR DESCRIPTION
Closes https://github.com/turnkeylinux/tracker/issues/1602