### PR TITLE
Minor bugfix for use of 3rd party php

### DIFF
--- a/conf/bootstrap_apt
+++ b/conf/bootstrap_apt
@@ -70,8 +70,8 @@ EOF
 
 if [ -n "$PHP_VERSION" ]; then
     # Use 3rd party sury.org repo
-    # install support for https repo
-    PKGS="lsb-release ca-certificates"
+    # install support for https repo & wget (to download gpg key)
+    PKGS="lsb-release ca-certificates wget"
     apt-get update
     DEBIAN_FRONTEND=noninteractive apt-get install -y $PKGS
 


### PR DESCRIPTION
Install wget when adding 3rd party php repo (otherwise can't download key).