### PR TITLE
improve IPv6 support

### DIFF
--- a/overlays/turnkey.d/shellinabox/etc/stunnel/shellinabox.conf
+++ b/overlays/turnkey.d/shellinabox/etc/stunnel/shellinabox.conf
@@ -55,6 +55,6 @@ renegotiation = no
 ciphers=
 
 [shellinabox]
-accept  = 12320
+accept  = :::12320
 connect = 127.0.0.1:12319
 TIMEOUTclose = 0

--- a/overlays/turnkey.d/webmin/etc/stunnel/webmin.conf
+++ b/overlays/turnkey.d/webmin/etc/stunnel/webmin.conf
@@ -55,6 +55,6 @@ renegotiation = no
 ciphers=
 
 [webmin]
-accept  = 12321
+accept  = :::12321
 connect = 127.0.0.1:10000
 TIMEOUTclose = 0

--- a/plans/turnkey/base
+++ b/plans/turnkey/base
@@ -74,6 +74,7 @@ webmin-syslog
 
 iptables
 webmin-firewall
+webmin-firewall6
 fail2ban
 webmin-fail2ban
 


### PR DESCRIPTION
* install package webmin-firewall6 by default
* listen on port 12320 (shellinabox) and 12321 (webmin) both for IPv4 and IPv6

closes https://github.com/turnkeylinux/tracker/issues/1658