### PR TITLE
Update Apache ssl.conf for 17.0

### DIFF
--- a/overlays/apache/etc/apache2/mods-available/ssl.conf
+++ b/overlays/apache/etc/apache2/mods-available/ssl.conf
@@ -65,7 +65,7 @@
 	# the CPU cost, and did not override SSLCipherSuite in a way that puts
 	# insecure ciphers first.
 	# Default: Off
-	SSLHonorCipherOrder on
+	#SSLHonorCipherOrder on
 
 	#   The protocols to enable.
 	#   Available values: all, SSLv3, TLSv1, TLSv1.1, TLSv1.2
@@ -86,6 +86,16 @@
 
     # Default certificate file to use (provided by TurnKey)
     SSLCertificateFile /etc/ssl/private/cert.pem
+
+    # enable HTTP/2, if available
+    Protocols h2 http/1.1
+
+    # OCSP Stapling
+    SSLUseStapling On
+    SSLStaplingCache "shmcb:logs/ssl_stapling(32768)"
+
+    # HTTP Strict Transport Security (mod_headers is required) (63072000 seconds)
+    Header always set Strict-Transport-Security "max-age=63072000"
 
 </IfModule>
 


### PR DESCRIPTION
Fairly minor update for Apache/LAMP apps for v17.0:
- disable cipher order (no longer required with the secure cipher suites we use; mild improvement in cpu resources)
- enable HTTP/2 (where possible)
- configure OCSP stapling (will only work once a proper cert is configured
- enable HSTS by default (only effects HTTPS - full implementation also requires HTTP redirect to HTTPS)

@OnGle 