### PR TITLE
Apache fix up

### DIFF
--- a/conf/apache-headers
+++ b/conf/apache-headers
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+# Enable headers module - so HSTS headers work (included in ssl.conf)
+
+a2enmod headers

--- a/mk/turnkey/apache.mk
+++ b/mk/turnkey/apache.mk
@@ -1,0 +1,2 @@
+COMMON_OVERLAYS += apache
+COMMON_CONF += apache-vhost apache-headers

--- a/mk/turnkey/fileserver.mk
+++ b/mk/turnkey/fileserver.mk
@@ -1,2 +1,4 @@
-COMMON_OVERLAYS += apache samba-fileserver samba-sid-inithook samba-dav nfs tkl-webcp
-COMMON_CONF += apache-vhost fileserver-storage samba-rootpass samba-webmin samba-dav nfs tkl-webcp
+COMMON_OVERLAYS += samba-fileserver samba-sid-inithook samba-dav nfs tkl-webcp
+COMMON_CONF += fileserver-storage samba-rootpass samba-webmin samba-dav nfs tkl-webcp
+
+include $(FAB_PATH)/common/mk/turnkey/apache.mk

--- a/mk/turnkey/lamp.mk
+++ b/mk/turnkey/lamp.mk
@@ -1,7 +1,8 @@
 WEBMIN_FW_TCP_INCOMING = 22 80 443 12320 12321 12322
 
-COMMON_OVERLAYS += apache adminer confconsole-lamp
-COMMON_CONF += apache-vhost apache-cgi adminer-apache adminer-mysql
+COMMON_OVERLAYS += adminer confconsole-lamp
+COMMON_CONF += apache-cgi adminer-apache adminer-mysql
 
+include $(FAB_PATH)/common/mk/turnkey/apache.mk
 include $(FAB_PATH)/common/mk/turnkey/php.mk
 include $(FAB_PATH)/common/mk/turnkey/mysql.mk

--- a/mk/turnkey/lapp.mk
+++ b/mk/turnkey/lapp.mk
@@ -1,7 +1,8 @@
 WEBMIN_FW_TCP_INCOMING = 22 80 443 12320 12321 12322
 
-COMMON_OVERLAYS += apache adminer confconsole-lapp
-COMMON_CONF += apache-vhost apache-cgi adminer-apache adminer-pgsql
+COMMON_OVERLAYS += adminer confconsole-lapp
+COMMON_CONF += apache-cgi adminer-apache adminer-pgsql
 
+include $(FAB_PATH)/common/mk/turnkey/apache.mk
 include $(FAB_PATH)/common/mk/turnkey/php.mk
 include $(FAB_PATH)/common/mk/turnkey/pgsql.mk

--- a/mk/turnkey/rails-pgsql.mk
+++ b/mk/turnkey/rails-pgsql.mk
@@ -2,5 +2,7 @@
 include $(FAB_PATH)/common/mk/turnkey/pgsql.mk
 
 # it is also important that rails goes before rails-pgsql
-COMMON_OVERLAYS += yarn rails rails-pgsql apache
-COMMON_CONF += yarn rails-pgsql apache-vhost
+COMMON_OVERLAYS += yarn rails rails-pgsql
+COMMON_CONF += yarn rails-pgsql
+
+include $(FAB_PATH)/common/mk/turnkey/apache.mk

--- a/mk/turnkey/rails.mk
+++ b/mk/turnkey/rails.mk
@@ -1,4 +1,5 @@
-COMMON_OVERLAYS += yarn rails apache 
-COMMON_CONF += yarn rails apache-vhost 
+COMMON_OVERLAYS += yarn rails
+COMMON_CONF += yarn rails
 
+include $(FAB_PATH)/common/mk/turnkey/apache.mk
 include $(FAB_PATH)/common/mk/turnkey/mysql.mk

--- a/mk/turnkey/web2py.mk
+++ b/mk/turnkey/web2py.mk
@@ -1,6 +1,7 @@
 WEBMIN_FW_TCP_INCOMING = 22 80 443 12320 12321
 
-COMMON_OVERLAYS += web2py apache github-latest-release
-COMMON_CONF += web2py apache-vhost
+COMMON_OVERLAYS += web2py github-latest-release
+COMMON_CONF += web2py
 
+include $(FAB_PATH)/common/mk/turnkey/apache.mk
 include $(FAB_PATH)/common/mk/turnkey/mysql.mk


### PR DESCRIPTION
This really should have been part of https://github.com/turnkeylinux/common/pull/204.

Primarily it enables the Apache headers module (i.e. runs `a2enmod headers`). This is required for HSTS support (which is now included by default in ssl.conf).

I have refactored things a bit so that now instead of adhoc including specific Apache related conf scripts and overlay, there is a dedicated `apache.mk` file.