### PR TITLE
Ansible tweaks

### DIFF
--- a/overlays/turnkey.d/github-latest-release/usr/local/bin/gh_releases
+++ b/overlays/turnkey.d/github-latest-release/usr/local/bin/gh_releases
@@ -14,10 +14,20 @@ usage() {
     cat >&2 <<EOF
 Usage: $(basename $0) <user>/<repo>
 
+Env Vars:
+    # used for github api
+    GITHUB_USER
+    GITHUB_USER_TOKEN
+
+    # retain temp files and set x if set
+    DEBUG
+
+    # omit tags or releases in output respectively if set
+    NO_TAGS
+    NO_RELEASES
+
 Note: Setting GITHUB_USER and GITHUB_USER_TOKEN environment variables are
       recommended. If not set, multipage results may be unreliable.
-
-      For debugging, set DEBUG=y.
 EOF
 }
 
@@ -36,6 +46,13 @@ if [[ -n "$GITHUB_USER" ]] && [[ -n "$GITHUB_USER_TOKEN" ]]; then
 else
     warning $warn "Authentication won't be used."
     USER=""
+fi
+
+if [[ -n "$NO_TAGS" ]]; then
+    warning "omitting tags (NO_TAGS is set)"
+fi
+if [[ -n "$NO_RELEASES" ]]; then
+    warning "omitting releases (NO_RELEASES is set)"
 fi
 
 echo -n "Fetching releases from github for '$repo_path'... " 1>&2
@@ -68,8 +85,8 @@ get_all_pages() {
     done
 }
 
-get_all_pages "https://api.github.com/repos/${repo_path}/releases" "tag_name"
-get_all_pages "https://api.github.com/repos/${repo_path}/tags" "name"
+[[ -z $NO_RELEASES ]] && get_all_pages "https://api.github.com/repos/${repo_path}/releases" "tag_name"
+[[ -z $NO_TAGS ]] && get_all_pages "https://api.github.com/repos/${repo_path}/tags" "name"
 
 echo "Done!" 1>&2
 cat $tmp_dir/releases | sort --version-sort --unique

--- a/overlays/turnkey.d/systemd-chroot/usr/local/bin/systemctl
+++ b/overlays/turnkey.d/systemd-chroot/usr/local/bin/systemctl
@@ -44,7 +44,7 @@ fi
 unset COMMAND SERVICE_NAME QUIET IGNORED
 while [[ "$#" -gt 0 ]]; do
     case $1 in
-        start|stop|restart|reload|enable|disable|mask|unmask|is-failed|is-active|daemon-reload)
+        start|stop|restart|reload|enable|disable|mask|unmask|is-failed|is-active|daemon-reload|list-units)
             if [[ -z "$COMMAND" ]]; then
                 COMMAND=$1
                 shift
@@ -87,7 +87,7 @@ if [[ -n "$COMMAND" ]]; then
             warning "--quiet is only honored with commands is-active|is-failed."
     fi
 
-    if [[ "$COMMAND" != "daemon-reload" ]] && [[ -z "$SERVICE_NAME" ]]; then
+    if [[ "$COMMAND" != "daemon-reload" ]] && [[ "$COMMAND" != "list-units" ]] && [[ -z "$SERVICE_NAME" ]]; then
         fatal "Service name required with $COMMAND"
     fi
 
@@ -109,6 +109,10 @@ if [[ -n "$COMMAND" ]]; then
 
         daemon-reload)
             warning "Ignoring daemon-reload, init scripts not cached."
+            exit 0;;
+
+        list-units)
+            warning "list-units: Running in chroot, ignoring" >&2
             exit 0;;
 
         is-failed|is-active)


### PR DESCRIPTION
- adds ability to mask out tags or releases from the `gh_releases` script via `NO_TAGS` and `NO_RELEASES` environment variables. e.g.

```bash
only_tags=$(NO_RELEASES=y gh_releases ...)
only_releases=$(NO_TAGS=y gh_releases...)
```

- adds dummy `list-units` command to systemctl, currently does nothing.