### PR TITLE
also build 'php-common' dummy package for use with 3rd party PHP.

### DIFF
--- a/conf/bootstrap_apt
+++ b/conf/bootstrap_apt
@@ -18,9 +18,9 @@ fatal() {
 }
 
 build_dummy_pkg() {
-    PKG=$1
+    declare PKG=$1
     mkdir -p /tmp/$PKG/DEBIAN
-    PKG_V="2:${PHP_VERSION}"
+    declare PKG_V="2:${PHP_VERSION}"
     cd  /tmp
     cat > /tmp/$PKG/DEBIAN/control <<EOF
 Package: $PKG

--- a/conf/bootstrap_apt
+++ b/conf/bootstrap_apt
@@ -17,6 +17,30 @@ fatal() {
     exit 1
 }
 
+build_dummy_pkg() {
+    PKG=$1
+    mkdir -p /tmp/$PKG/DEBIAN
+    PKG_V="2:${PHP_VERSION}"
+    cd  /tmp
+    cat > /tmp/$PKG/DEBIAN/control <<EOF
+Package: $PKG
+Version: $PKG_V
+Section: custom
+Priority: optional
+Architecture: all
+Essential: no
+Depends: php${PHP_VERSION}-mysql
+Installed-Size: 1024
+Maintainer: Jeremy Davis <jeremy@turnkeylinux.org>
+Description: Dummy Package to ensure correct version of PHP packages are installed.
+EOF
+    dpkg-deb --build ${PKG}
+    DEBIAN_FRONTEND=noninteractive apt-get install ./${PKG}.deb -y --allow-downgrades --autoremove
+    apt-mark hold ${PKG}="${PKG_V}"
+    cd -
+    rm -rf /tmp/${PKG}*
+}
+
 [ -n "$CODENAME" ] || fatal "CODENAME is not set"
 
 SOURCES_LIST=/etc/apt/sources.list.d
@@ -174,28 +198,10 @@ EOF
     done
 
     # create php-mysql package that depends on PHP_VERSION - this allows adminer to install cleanly
-    PKG=php-mysql
-    mkdir -p /tmp/$PKG/DEBIAN
-    PKG_V="2:${PHP_VERSION}"
-    cd  /tmp
-    cat > /tmp/$PKG/DEBIAN/control <<EOF
-Package: php-mysql
-Version: $PKG_V
-Section: custom
-Priority: optional
-Architecture: all
-Essential: no
-Depends: php${PHP_VERSION}-mysql
-Installed-Size: 1024
-Maintainer: Jeremy Davis <jeremy@turnkeylinux.org>
-Description: Dummy Package to allow Adminer to install cleanly without Debian php-mysql package.
-EOF
+    # also, in bullseye, it looks like we also need to make a dummy php-common package?!
     apt-get update
-    dpkg-deb --build ${PKG}
-    DEBIAN_FRONTEND=noninteractive apt-get install ./${PKG}.deb -y --allow-downgrades --autoremove
-    apt-mark hold php-mysql="${PKG_V}"
-    cd -
-    rm -rf /tmp/${PKG}*
+    build_dummy_pkg php-common
+    build_dummy_pkg php-mysql
 fi
 
 if [ "$NONFREE" ]; then


### PR DESCRIPTION
Hack to workaround PHP7.3 install issues for v17.x.