### PR TITLE
Revert previous changes and actually fix the issue

### DIFF
--- a/conf/bootstrap_apt
+++ b/conf/bootstrap_apt
@@ -17,30 +17,6 @@ fatal() {
     exit 1
 }
 
-build_dummy_pkg() {
-    declare PKG=$1
-    mkdir -p /tmp/$PKG/DEBIAN
-    declare PKG_V="2:${PHP_VERSION}"
-    cd  /tmp
-    cat > /tmp/$PKG/DEBIAN/control <<EOF
-Package: $PKG
-Version: $PKG_V
-Section: custom
-Priority: optional
-Architecture: all
-Essential: no
-Depends: php${PHP_VERSION}-mysql
-Installed-Size: 1024
-Maintainer: Jeremy Davis <jeremy@turnkeylinux.org>
-Description: Dummy Package to ensure correct version of PHP packages are installed.
-EOF
-    dpkg-deb --build ${PKG}
-    DEBIAN_FRONTEND=noninteractive apt-get install ./${PKG}.deb -y --allow-downgrades --autoremove
-    apt-mark hold ${PKG}="${PKG_V}"
-    cd -
-    rm -rf /tmp/${PKG}*
-}
-
 [ -n "$CODENAME" ] || fatal "CODENAME is not set"
 
 SOURCES_LIST=/etc/apt/sources.list.d
@@ -169,11 +145,11 @@ Package: libzip4
 Pin: origin packages.sury.org
 Pin-Priority: 550
 
-# only enable below if using latest php version
-#Package: php-common
-#Pin: origin packages.sury.org
-#Pin-Priority: 550
+Package: php-common
+Pin: origin packages.sury.org
+Pin-Priority: 550
 
+# only enable below if using latest php version
 #Package: php-imagick
 #Pin: origin packages.sury.org
 #Pin-Priority: 550
@@ -198,10 +174,28 @@ EOF
     done
 
     # create php-mysql package that depends on PHP_VERSION - this allows adminer to install cleanly
-    # also, in bullseye, it looks like we also need to make a dummy php-common package?!
+    PKG=php-mysql
+    mkdir -p /tmp/$PKG/DEBIAN
+    PKG_V="2:${PHP_VERSION}"
+    cd  /tmp
+    cat > /tmp/$PKG/DEBIAN/control <<EOF
+Package: php-mysql
+Version: $PKG_V
+Section: custom
+Priority: optional
+Architecture: all
+Essential: no
+Depends: php${PHP_VERSION}-mysql
+Installed-Size: 1024
+Maintainer: Jeremy Davis <jeremy@turnkeylinux.org>
+Description: Dummy Package to allow Adminer to install cleanly without Debian php-mysql package.
+EOF
     apt-get update
-    build_dummy_pkg php-common
-    build_dummy_pkg php-mysql
+    dpkg-deb --build ${PKG}
+    DEBIAN_FRONTEND=noninteractive apt-get install ./${PKG}.deb -y --allow-downgrades --autoremove
+    apt-mark hold php-mysql="${PKG_V}"
+    cd -
+    rm -rf /tmp/${PKG}*
 fi
 
 if [ "$NONFREE" ]; then


### PR DESCRIPTION
It turns out that I didn't understand the issue properly. Unlike the other php-PKG_NAME packages that have a phpX.Y-PKG_NAME counterpart, the php-common package, actually includes some important scripts. Namely the phpenmod and phpdismod commands. So a real php-common package needs to be installed from somewhere, or php module package installs will fail (when they call 'phpenmod').

Installing the default Debian one, pulls in other default Debian PHP packages so that's not an option. But the sury.org php-common installs cleanly. It also does not pull in the latest phpX.Y-common as other sury.org php-PKG_NAME packages do (e.g. php-mysql will pull in the latest phpX.Y-mysql).