### PR TITLE
Update common for faveo-helpdesk appliance; Depends on 

### DIFF
--- a/conf/bootstrap_apt
+++ b/conf/bootstrap_apt
@@ -117,10 +117,6 @@ deb [signed-by=$keyfile] https://packages.sury.org/php/ $CODENAME main
 EOF
 
     cat > /etc/apt/preferences.d/php-sury.pref <<EOF
-Package: *
-Pin: origin packages.sury.org
-Pin-Priority: 10
-
 Package: php${PHP_VERSION}-*
 Pin: origin packages.sury.org
 Pin-Priority: 550
@@ -148,6 +144,10 @@ Pin-Priority: 550
 Package: php-common
 Pin: origin packages.sury.org
 Pin-Priority: 550
+
+Package: *
+Pin: origin packages.sury.org
+Pin-Priority: 10
 
 # only enable below if using latest php version
 #Package: php-imagick

--- a/plans/turnkey/lamp73
+++ b/plans/turnkey/lamp73
@@ -1,0 +1,15 @@
+#include <turnkey/mysql>
+
+/* normal lamp components */
+apache2
+webmin-apache
+
+webmin-phpini
+
+adminer
+
+/* PHP 7.3 specific */
+
+php7.3-mysql
+libapache2-mod-php7.3
+php7.3-cli


### PR DESCRIPTION
Updating common plan to include lamp plan for php version 7.3 specifically for faveo-helodesk appliance. Changes made to common/conf/bootstrap_apt ensure pin priority is set correctly to install php packages from sury.org repository instead of debian repo.