### PR TITLE
Update smb.conf

### DIFF
--- a/overlays/samba-fileserver/etc/samba/smb.conf
+++ b/overlays/samba-fileserver/etc/samba/smb.conf
@@ -6,7 +6,11 @@
     os level = 20
     security = user
     passdb backend = tdbsam
-    restrict anonymous = 2
+    
+    #uncommenting the following parameter will prevent any guest access (public sharing)
+    #restrict anonymous = 2  
+    #used for guest access
+    map to guest = bad user
 
     admin users = root
     encrypt passwords = true
@@ -62,4 +66,5 @@
     read only = no
     create mask = 0644
     directory mask = 0755
+    guest ok = yes
 


### PR DESCRIPTION
Proposing: The "restrict anonymous = 2" parameter will prevent guest (public) sharing for anonymous users. To support guest access out of the box, it should be removed or modified and the "map to guest" parameter added.

Background: Some years ago, old Samba documentation states you could set the global parameter "security = share" and the share parameter "guest ok = yes" would override the global parameter "restrict anonymous = 2". However, the samba daemon will no longer even start with security set to share level. That security level has been removed.

In addition, to configure a share for guest (public) sharing, the Samba FAQ states that a minimal configuration should include the parameter "map to guest = bad user". 

Note that the current sample smb.conf in Debian (at /usr/share/samba/smb.conf) both omits the "restrict anonymous" parameter and includes the "map to guest" parameter by default. The TKL default smb.conf provided here is non-standard for these parameters, particularly for a File Server application.

Without these changes to the smb.conf, guest sharing will not work. And while the Webmin interface supports the "guest ok" and "guest only" in file shares, its options cannot take effect as it has no GUI that can modify or supply these parameters.

Additionally, the example [Storage] share with the comment "Public Share" at the end of the file will not allow guest (i.e. public) access because it lacks the parameter "guest ok = yes". As it currently stands, this example share is instead a user-password protected share. 

See: https://www.turnkeylinux.org/forum/support/tue-20221101-1123/turnkey-linux-file-server-smb-no-guest-access-possible-oob