### PR TITLE
Initial BashLib implementation

### DIFF
--- a/mk/turnkey/fileserver.mk
+++ b/mk/turnkey/fileserver.mk
@@ -1,4 +1,5 @@
-COMMON_OVERLAYS += samba-fileserver samba-sid-inithook samba-dav nfs tkl-webcp
-COMMON_CONF += fileserver-storage samba-rootpass samba-webmin samba-dav nfs tkl-webcp
+COMMON_OVERLAYS += samba-fileserver samba-sid-inithook samba-dav nfs
+COMMON_CONF += fileserver-storage samba-rootpass samba-webmin samba-dav nfs
 
+include $(FAB_PATH)/common/mk/turnkey/tkl-webcp.mk
 include $(FAB_PATH)/common/mk/turnkey/apache.mk

--- a/mk/turnkey/nodejs-tklwebcp.mk
+++ b/mk/turnkey/nodejs-tklwebcp.mk
@@ -1,4 +1,5 @@
+include $(FAB_PATH)/common/mk/turnkey/tkl-webcp.mk
 include $(FAB_PATH)/common/mk/turnkey/nginx-nodejs.mk
 
-COMMON_OVERLAYS += tkl-webcp nodejs-pm2-tklwebcp
-COMMON_CONF += tkl-webcp nodejs-pm2-tklwebcp
+COMMON_OVERLAYS += nodejs-pm2-tklwebcp
+COMMON_CONF += nodejs-pm2-tklwebcp

--- a/mk/turnkey/tkl-webcp.mk
+++ b/mk/turnkey/tkl-webcp.mk
@@ -1,0 +1,2 @@
+COMMON_OVERLAYS += tkl-webcp
+COMMON_CONF += tkl-webcp

--- a/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/README.rst
+++ b/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/README.rst
@@ -1,0 +1,57 @@
+TKLDev BashLib
+==============
+
+TKLDev BashLib (aka tkl-bashlib or just bashlib) is a collection of bash
+functions and presets envrionment variables to assist with DRY_ TKLDev_
+TurnKey GNU/Linux appliance buildcode_.
+
+Contents
+--------
+
+It consists of an 'init.sh' file and a number of '.bash' files. 'init.sh'
+is the core file that needs to be sourced in an appliance conf script prior
+to use of bashlib. 'init.sh' itself contains some base env vars and functions
+and will load (source) all other '.bash' files in this directory.
+
+Usage
+-----
+
+Note that 'init'sh' is intended to be sourced, not executed directly. To
+load bashlib, simply source 'init.sh' in your conf script. I.e.::
+
+    source /usr/local/src/tkl-bashlib/init.sh
+
+Note that bashlib functions should be available for use within any conf
+script (assuming init.sh has been sourced as above). Bashlib is removed prior
+to building the ISO, so can only be leveraged at build time (i.e. not in the
+built ISO/installed system).
+
+Licence
+-------
+
+As part of common_, TKLDev BashLib is licenced under GPLv3_ (or a later version
+at your discretion).
+
+Contributing
+------------
+
+The source of this code can be found locally on TKLDev within::
+
+    ${FAB_PATH}/common/overlays/turnkey.d/tkl-bashlib
+
+Or on GitHub, within the common_ repository, specifically
+`overlays/turnkey.d/tkldev-bashlib`_.
+
+To contribute to the development of bashlib, please open a pull request.
+
+Generally it is desireable to only add new '.bash' files. That is because
+existing appliance buildcode may depend on the current code "as is"
+(including any buggy behvaiour). So please be especially careful if/when
+modifying existing files and functions.
+
+.. _DRY: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself
+.. _TKLDev: https://www.turnkeylinux.org/tkldev
+.. _buildcode: https://github.com/turnkeylinux-apps/
+.. _common: https://github.com/turnkeylinux/common
+.. _GPLv3: https://www.gnu.org/licenses/gpl-3.0.en.html
+.. _overlays/turnkey.d/tkldev-bashlib: https://github.com/turnkeylinux/common/tree/master/overlays/turnkey.d/tkl-bashlib

--- a/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/README.rst
+++ b/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/README.rst
@@ -46,7 +46,7 @@ To contribute to the development of bashlib, please open a pull request.
 
 Generally it is desireable to only add new '.bash' files. That is because
 existing appliance buildcode may depend on the current code "as is"
-(including any buggy behvaiour). So please be especially careful if/when
+(including any buggy behaviour). So please be especially careful if/when
 modifying existing files and functions.
 
 .. _DRY: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself

--- a/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/init
+++ b/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/init
@@ -1,0 +1,50 @@
+# This script is provided by TurnKey GNU/Linux to allow reuse of bash code
+# snippets in TKLDev appliance build code.
+#
+# This init script contains some base setup and loads all other .bash files
+# in this directory.
+#
+# It is provided by common/overlays/turnkey.d/tkl-bashlib
+#
+# To use it, source this base 'init' script:
+#
+#     source /usr/local/src/tkl-bashlib/init
+#
+# Licence: GPLv3 (or later)
+
+# set proxy env vars (if not already set)
+if [[ -n "${FAB_HTTP_PROXY}" ]]; then
+    if [[ -z "${http_proxy}" ]]; then
+        export http_proxy=${FAB_HTTP_PROXY}
+    fi
+fi
+if [[ -n "${FAB_HTTPS_PROXY}" ]]; then
+    if [[ -z "${https_proxy}" ]]; then
+        export https_proxy=${FAB_HTTPS_PROXY}
+    fi
+fi
+
+# set non-interactive dpkg/apt front end
+export DEBIAN_FRONTEND=noninteractive
+
+# functions for errors and warnings
+fatal() { echo "FATAL: ${@}" >&2; exit 1; }
+warn() { echo "WARN: ${@}" >&2; exit 1; }
+
+# check for integers
+# if any elements of $@ are _not_ integers - will return 1
+is_integer() {
+    [[ "$#" -gt 0 ]] || fatal "is_integer requires at least one argument"
+    for item in $@; do
+        if [[ -n "${item##*[!0-9]*}" ]]; then
+            continue
+        else
+            return 1
+        fi
+    done
+}
+
+# load all other .bash files
+for _f in $(dirname ${BASH_SOURCE[0]})/*.bash; do
+    source ${_f}
+done

--- a/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/init.sh
+++ b/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/init.sh
@@ -13,15 +13,11 @@
 # the same dir as this file).
 
 # set proxy env vars (if not already set)
-if [[ -n "${FAB_HTTP_PROXY}" ]]; then
-    if [[ -z "${http_proxy}" ]]; then
-        export http_proxy=${FAB_HTTP_PROXY}
-    fi
+if [[ -n "${FAB_HTTP_PROXY}" ]] && [[ -z "${http_proxy}" ]]; then
+    export http_proxy=${FAB_HTTP_PROXY}
 fi
-if [[ -n "${FAB_HTTPS_PROXY}" ]]; then
-    if [[ -z "${https_proxy}" ]]; then
-        export https_proxy=${FAB_HTTPS_PROXY}
-    fi
+if [[ -n "${FAB_HTTPS_PROXY}" ]] && [[ -z "${https_proxy}" ]]; then
+    export https_proxy=${FAB_HTTPS_PROXY}
 fi
 
 # set non-interactive dpkg/apt front end

--- a/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/init.sh
+++ b/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/init.sh
@@ -1,16 +1,16 @@
-# This script is provided by TurnKey GNU/Linux to allow reuse of bash code
-# snippets in TKLDev appliance build code.
+# (c) 2022 - TurnKey GNU/Linux - all rights reserved
 #
-# This init script contains some base setup and loads all other .bash files
-# in this directory.
+# This script is part of TKLDev BashLib.
 #
-# It is provided by common/overlays/turnkey.d/tkl-bashlib
+# The source can be located locally on TKLDev:
+#   ${FAB_PATH}/common/overlays/turnkey.d/tkl-bashlib
 #
-# To use it, source this base 'init' script:
+# To use it within a conf script, first source this base 'init' script:
 #
-#     source /usr/local/src/tkl-bashlib/init
+#   source /usr/local/src/tkl-bashlib/init
 #
-# Licence: GPLv3 (or later)
+# For more info, including licence, please see the README.rst (should be in
+# the same dir as this file).
 
 # set proxy env vars (if not already set)
 if [[ -n "${FAB_HTTP_PROXY}" ]]; then

--- a/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/mysql_setup.bash
+++ b/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/mysql_setup.bash
@@ -1,5 +1,16 @@
-# Part of - and requires - tkl-bashlib
-# - see 'init' script in this directory for more info
+# (c) 2022 - TurnKey GNU/Linux - all rights reserved
+#
+# This script is part of TKLDev BashLib.
+#
+# The source can be located locally on TKLDev:
+#   ${FAB_PATH}/common/overlays/turnkey.d/tkl-bashlib
+#
+# To use it within a conf script, first source the base 'init' script:
+#
+#   source /usr/local/src/tkl-bashlib/init
+#
+# For more info, including licence, please see the README.rst (should be in
+# the same dir as this file).
 
 # initialise mysql (mariadb) database and user
 tkl_mysql_setup() {

--- a/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/mysql_setup.bash
+++ b/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/mysql_setup.bash
@@ -1,0 +1,24 @@
+# Part of - and requires - tkl-bashlib
+# - see 'init' script in this directory for more info
+
+# initialise mysql (mariadb) database and user
+tkl_mysql_setup() {
+    [[ "$#" -eq 3 ]] \
+        || fatal "tkl_mysql_setup requires 3 args: DB name, username & password"
+
+    service mysql start
+
+    local db_name=${1}
+    local db_user=${2}
+    local db_pass=${3}
+
+    mysqladmin create ${db_name}
+    mysql --batch --execute "GRANT ALL PRIVILEGES
+                             ON ${db_name}.*
+                             TO ${db_user}@localhost
+                             IDENTIFIED BY '${db_pass}';
+                             flush privileges;"
+    mysql --batch --execute "ALTER DATABASE ${db_name}
+                             CHARACTER SET utf8mb4
+                             COLLATE utf8mb4_bin;"
+}

--- a/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/wait_til_ready.bash
+++ b/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/wait_til_ready.bash
@@ -1,5 +1,16 @@
-# Part of - and requires - tkl-bashlib
-# - see 'init' script in this directory for more info
+# (c) 2022 - TurnKey GNU/Linux - all rights reserved
+#
+# This script is part of TKLDev BashLib.
+#
+# The source can be located locally on TKLDev:
+#   ${FAB_PATH}/common/overlays/turnkey.d/tkl-bashlib
+#
+# To use it within a conf script, first source the base 'init' script:
+#
+#   source /usr/local/src/tkl-bashlib/init
+#
+# For more info, including licence, please see the README.rst (should be in
+# the same dir as this file).
 
 # check if port is listening
 port_listening() {

--- a/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/wait_til_ready.bash
+++ b/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/wait_til_ready.bash
@@ -1,0 +1,108 @@
+# Part of - and requires - tkl-bashlib
+# - see 'init' script in this directory for more info
+
+# check if port is listening
+port_listening() {
+
+    local port=${1}
+
+    [[ "$#" -eq 1 ]] \
+        || fatal "port_listening requires 1 arg: port number (integer)"
+    $(is_integer ${port}) || fatal "port_listening arg must be integer"
+
+    if netstat -tlnp | grep -q ":${port} "; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# check http status return code of webserver
+get_http_status() {
+
+    local port=${1:-auto}
+    local schema=${2:-auto}
+    local args="-I"
+
+    case ${port} in
+        auto)
+            if port_listening 443; then
+                port=443
+                schema=https
+            elif port_listening 80; then
+                port=80
+                schema=http
+            else
+                fatal "Auto failed - No process listening on ports 80 or 443"
+            fi;;
+        [0-9]+)
+            if [[ "${schema}" != http?(s) ]]; then
+                fatal "Schema (${schema}) must be http|https when port explicitly set"
+            elif ! port_listening ${port}; then
+                fatal "No process listening on port (${port})"
+            fi;;
+        *)
+            fatal "Port must be an integer, 'auto' or unset (${port})";;
+    esac
+
+    curl ${args} ${schema}://localhost:${port} 2>/dev/null \
+        | head -1 | sed -nE "s|^.*([0-9]{3}).*|\1|p"
+}
+
+# wait for specific http status code
+# syntax:
+# wait_for_code <retry_code> <success_code> <sleep_secs> <max_retries>
+# defaults:       502           200              5           30
+# (total max wait: 2min 30sec)
+wait_for_http_code() {
+
+    local retry_code=${1:-502}
+    local success_code=${2:-200}
+    local sleep_sec=${3:-5}
+    local max_retries=${4:-30}
+    local _count=0
+
+    if ! is_integer ${retry_code} ${success_code} \
+                    ${sleep_secs} ${max_retries}; then
+        fatal "wait_for_http_code function only accepts integer arguments"
+    fi
+
+    while http_code=$(get_http_status); do
+        _count=$((_count + 1))
+        case ${http_code} in
+            ${success_code})
+                echo "Ok (http code: ${success_code} - waited "\
+                     "$((sleep_sec * _count)))"
+                break;;
+            ${retry_code})
+                echo "retrying in ${sleep_sec} sec (http code: ${retry_code})"
+                sleep ${sleep_sec};;
+            *)
+                fatal "Unexpected HTTP response: ${http_code}";;
+        esac
+        if [[ ${_count} -gt $((max_retries + 1)) ]]; then
+            fatal "Waited over $((max_retries * sleep_sec)) seconds - giving up."
+        fi
+    done
+}
+
+# wait for port to be listening
+wait_for_listen() {
+
+    local port=${1}
+    local sleep_sec=${2:-2}
+    local max_retries=${3:-30}
+    local _count=0
+
+    if ! is_integer ${port} ${sleep_secs} ${max_retries}; then
+        fatal "wait_for_code function only accepts integer arguments"
+    fi
+
+    while ! port_listening ${port}; do
+        _count=$((_count + 1))
+        sleep ${sleep_sec}
+        if [[ ${_count} -gt $((max_retries + 1)) ]]; then
+            fatal "Waited over $((max_retries * sleep_sec)) seconds - giving up."
+        fi
+    done
+}

--- a/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/wait_til_ready.bash
+++ b/overlays/turnkey.d/tkl-bashlib/usr/local/src/tkl-bashlib/wait_til_ready.bash
@@ -56,6 +56,7 @@ get_http_status() {
             fatal "Port must be an integer, 'auto' or unset (${port})";;
     esac
 
+    [[ "${schema}" != "https" ]] || args="${args} --insecure"
     curl ${args} ${schema}://localhost:${port} 2>/dev/null \
         | head -1 | sed -nE "s|^.*([0-9]{3}).*|\1|p"
 }

--- a/removelists-final/turnkey
+++ b/removelists-final/turnkey
@@ -12,3 +12,6 @@
 # rm common systemctl chroot workaround(s)
 /usr/local/bin/service
 /usr/local/bin/systemctl
+
+# rm bashlib
+/usr/local/src/tkl-bashlib


### PR DESCRIPTION
This is an initial implementation of "BashLib" as has been threatened (and desired) for some time.

It has been developed alongside v17.x update of CouchDB and Etherpad so only includes functions specific to (and now required by) them so there is lots of room for extension. Also, whilst I'm pretty comfortable with bash, there are so many different ways to do things in bash, I'm sure that the current code could be further generalised and/or improved.

The last commit (new `tkl-webcop.mk`) is unrelated to bashlib and probably should be in a separate PR, but it is required for couchdb and I wanted to finalise this too: https://github.com/turnkeylinux-apps/couchdb/pull/17