### PR TITLE
Fix web2py apache conf - closes #1601.

### DIFF
--- a/overlays/web2py/etc/apache2/sites-available/web2py.conf
+++ b/overlays/web2py/etc/apache2/sites-available/web2py.conf
@@ -10,7 +10,7 @@ WSGIProcessGroup web2py
 
     RewriteEngine On
     RewriteCond %{HTTPS} !=on
-    RewriteRule ^/?admin/(.*) https://%{SERVER_NAME}/admin/$1 [R,L]
+    RewriteRule ^/?admin https://%{SERVER_NAME}/admin [R=307,L]
 </VirtualHost>
 
 <VirtualHost *:443>
@@ -19,8 +19,7 @@ WSGIProcessGroup web2py
 </VirtualHost>
 
 AliasMatch ^/([^/]+)/static/(?:_[\d]+.[\d]+.[\d]+/)?(.*) /var/www/web2py/applications/$1/static/$2
-<Directory /var/www/web2py/applications/*/static/>
-    Order Allow,Deny
-    Allow from all
-</Directory>
 
+<Directory /var/www/web2py/applications/*/static/>
+    Require all granted
+</Directory>


### PR DESCRIPTION
I've confirmed that this fixes a 500 error when trying to access Web2py admin area. This issue affects both the generic Web2py appliance and Sahana-Eden (based on Web2py).

Closes https://github.com/turnkeylinux/tracker/issues/1601