### PR TITLE
Backport pinning

### DIFF
--- a/conf/bootstrap_apt
+++ b/conf/bootstrap_apt
@@ -215,7 +215,7 @@ if [ "$BACKPORTS" ]; then
     mv $DEB_BACKPORT_LIST.disabled $DEB_BACKPORT_LIST
 
     # dynamically add some extra pins as specified in appliance Makefile
-    [[ -n "$BACKPORTS_PINS" ]] || fatal "BACKPORTS env var set bu no BACKPORTS_PINS specified"
+    [[ -n "$BACKPORTS_PINS" ]] || fatal "BACKPORTS env var set but no BACKPORTS_PINS specified"
     for package_name in $BACKPORTS_PINS; do
         cat >> /etc/apt/preferences.d/debian-backports.pref <<EOF
 Package: $package_name

--- a/conf/bootstrap_apt
+++ b/conf/bootstrap_apt
@@ -213,6 +213,16 @@ fi
 
 if [ "$BACKPORTS" ]; then
     mv $DEB_BACKPORT_LIST.disabled $DEB_BACKPORT_LIST
+
+    # dynamically add some extra pins as specified in appliance Makefile
+    for package_name in $BACKPORTS_PINS; do
+        cat >> /etc/apt/preferences.d/debian-backports.pref <<EOF
+Package: $package_name
+Pin: release a=$CODENAME-backports
+Pin-Priority: 500
+
+EOF
+    done
 fi
 
 # This hack ensures that any changes to 'Suite' and 'Version' changes are

--- a/conf/bootstrap_apt
+++ b/conf/bootstrap_apt
@@ -215,6 +215,7 @@ if [ "$BACKPORTS" ]; then
     mv $DEB_BACKPORT_LIST.disabled $DEB_BACKPORT_LIST
 
     # dynamically add some extra pins as specified in appliance Makefile
+    [[ -n "$BACKPORTS_PINS" ]] || fatal "BACKPORTS env var set bu no BACKPORTS_PINS specified"
     for package_name in $BACKPORTS_PINS; do
         cat >> /etc/apt/preferences.d/debian-backports.pref <<EOF
 Package: $package_name

--- a/mk/turnkey.mk
+++ b/mk/turnkey.mk
@@ -9,8 +9,8 @@ CONF_VARS += WEBMIN_THEME WEBMIN_FW_TCP_INCOMING WEBMIN_FW_TCP_INCOMING_REJECT W
 CONF_VARS += CREDIT_STYLE CREDIT_STYLE_EXTRA CREDIT_ANCHORTEXT CREDIT_LOCATION
 # these are needed to ensure github queries don't get limited
 CONF_VARS += GITHUB_USER GITHUB_USER_TOKEN
-# for dynamically adding pins to sury
-CONF_VARS += PHP_EXTRA_PINS
+# for dynamically adding pins to sury & backports respectively
+CONF_VARS += PHP_EXTRA_PINS BACKPORTS_PINS
 
 COMMON_OVERLAYS := turnkey.d $(COMMON_OVERLAYS)
 COMMON_CONF := turnkey.d $(COMMON_CONF)


### PR DESCRIPTION
This is mostly @OnGle's work, with a minor tweak by me.

It supports setting of `BACKPORTS` & `BACKPORTS_PINS` env vars in the appliance `Makefile`. When set, the relevant backports repo will be enabled and the noted packages pinned to backports (so will be installed at build time (`root.build`). The functionality is very similar to how `PHP_V` & `PHP_EXTRA_PINS` works.

Required by https://github.com/turnkeylinux-apps/domain-controller/pull/26