### PR TITLE
Jed's 18.x dev

### DIFF
--- a/conf/bootstrap_apt
+++ b/conf/bootstrap_apt
@@ -63,7 +63,7 @@ elif [[ $deb_ver -ge 11 ]]; then
     PROXY_PORT=3128
 fi
 
-if [[ "${APT_PROXY_OVERRIDE,,}" -eq "disable" ]]; then
+if [[ "${APT_PROXY_OVERRIDE,,}" == "disable" ]]; then
     PROXY_PORT=
 elif [[ -n $APT_PROXY_OVERRIDE ]]; then
     PROXY_PORT=$APT_PROXY_OVERRIDE

--- a/conf/bootstrap_apt
+++ b/conf/bootstrap_apt
@@ -210,7 +210,7 @@ Pin-Priority: 550
 EOF
     # dynamically add some extra pins as specified in appliance Makefile
     for package_name in $PHP_EXTRA_PINS; do
-        if grep -q "Package: $package_name" /etc/apt/preferences.d/php-sury.pref; then
+        if grep -q "^Package: $package_name\$" /etc/apt/preferences.d/php-sury.pref; then
             continue
         fi
         cat >> /etc/apt/preferences.d/php-sury.pref <<EOF

--- a/conf/bootstrap_apt
+++ b/conf/bootstrap_apt
@@ -1,12 +1,28 @@
 #!/bin/bash -e
+
 # create apt sources
 # environment variables:
-#   - required: CODENAME
-#   - optional: NONFREE
-#   - optional: TKL_TESTING
-#   - optional: BACKPORTS
-#   - optional: PHP_VERSION
-#   - optional: APT_PROXY_OVERRIDE
+#   - CODENAME <required>:
+#       - OS codename to use
+#   - NONFREE <optional>:
+#       - set to enable non-free by default
+#   - TKL_TESTING <optional>:
+#       - set to enable the TUrnKey testing repo
+#   - BACKPORTS <optional>:
+#       - set to enable Debian backports repo
+#   - PHP_VERSION <optional>:
+#       - set to desired PHP version from Sury PHP repo
+#   - PHP_EXTRA_PINS <optional>:
+#       - space separated list of additional Sury php pkgs to pin 500
+#   - APT_PROXY_OVERRIDE <optional>:
+#       - override proxy default proxy; use one of:
+#           - full remote url (starting with 'http/s')
+#           - port number (for localhost proxy)
+#           - 'disable' (disable proxy)
+#   - HOST_DEB_VER <optional>:
+#       - if not the same as guest, apply relevant transition changes
+#   - NO_TURNKEY_APT_REPO <optional>:
+#       - disable TurnKey apt repos - useful during early transition
 
 # Note, to install packages from backports:
 # - set 'BACKPORTS=y'; and either:
@@ -19,22 +35,29 @@ fatal() {
 }
 
 [ -n "$CODENAME" ] || fatal "CODENAME is not set"
-if grep "NO_TURNKEY_APT_REPO" /turnkey-transition-info; then
-    TRANSITION_NO_TURNKEY_APT_REPO=y
-fi
+[ ! -f /turnkey-buildenv ] || source /turnkey-buildenv
+rm -rf /turnkey-buildenv
 
 SOURCES_LIST=/etc/apt/sources.list.d
 PREFS_LIST=/etc/apt/preferences.d
 CONF_DIR=/etc/apt/apt.conf.d
 mkdir -p $SOURCES_LIST $PREFS_LIST $CONF_DIR
 
-# TEMP support 17.0rc build on 16.x
-guest_build=$(cat /etc/debian_version | cut -d. -f1 | cut -d/ -f2)
-BUSTER_BASE=""
-PROXY_PORT=3128
-if [[ "$guest_build" -eq "11" ]] && [[ -f /bullseye_on_buster ]]; then
-    export BUSTER_BASE=y
-    PROXY_PORT=8124
+# transition - add specific Debian base transition changes here
+deb_ver=$(sed -nE "s|^([0-9]+).*|\1|p" /etc/debian_version)
+if [[ -n "$HOST_DEB_VER" ]] && [[ "$HOST_DEB_VER" != "$deb_ver" ]]; then
+    echo "# Transition build detected - building v$deb_ver on v$HOST_DEB_VER"
+    if [[ $HOST_DEB_VER -ne $((deb_ver - 1)) ]]; then
+        fatal "Detected more than one Debian major version difference"
+    elif [[ $deb_ver -lt 9 ]]; then
+        fatal "Debian releases older than Stretch no longer supported"
+    elif [[ $deb_ver -le 10 ]]; then
+        sec_repo="$CODENAME/updates"
+        PROXY_PORT=8124
+    elif [[ $deb_ver -ge 11 ]]; then
+        sec_repo="$CODENAME-security"
+        PROXY_PORT=3128
+    fi
 fi
 
 if [[ "${APT_PROXY_OVERRIDE,,}" -eq "disable" ]]; then
@@ -54,17 +77,17 @@ fi
 # update CA certs (custom cacher cert should already have been added)
 if [[ -e /usr/local/share/ca-certificates/squid_proxyCA.crt ]]; then
     update-ca-certificates
-elif [[ -n "$BUSTER_BASE" ]]; then
-    echo "Buster base detected, skipping importing Squid CA cert."
+elif [[ $deb_ver -le 10 ]]; then
+    echo "Buster base (or earlier) detected, skipping importing Squid CA cert."
 else
     fatal "Squid CA cert not found."
 fi
 
-# Default Debian PHP version. This should return the current:
-#   apt-cache policy php | sed -n "\|Candidate:|s|.*:\([0-9]\.[0-9]*\)+.*|\1|p"
-DEBIAN_PHP_V=7.4
+# Set default Debian PHP version
+DEBIAN_PHP_V=$(apt-cache policy php \
+                | sed -n "\|Candidate:|s|.*:\([0-9]\.[0-9]*\)+.*|\1|p")
 
-if [[ -z "$TRANSITION_NO_TURNKEY_APT_REPO" ]]; then
+if [[ -z "$NO_TURNKEY_APT_REPO" ]]; then
     # keys are provided as ascii armoured for transparency; but secure apt requires
     # gpg keyring files
     key_dir=/usr/share/keyrings
@@ -79,12 +102,6 @@ if [[ -z "$TRANSITION_NO_TURNKEY_APT_REPO" ]]; then
     # ensure that gpg-agent is killed after processing keys
     kill -9 $(pidof gpg-agent) || true
     rm -rf $HOME/.gnupg
-fi
-
-if [[ "$CODENAME" == "stretch" ]] || [[ "$CODENAME" == "buster" ]];then
-    sec_repo="$CODENAME/updates"
-else
-    sec_repo="$CODENAME-security"
 fi
 
 cat > $SOURCES_LIST/sources.list <<EOF
@@ -114,7 +131,7 @@ deb http://deb.debian.org/debian $CODENAME-backports main
 #deb http://deb.debian.org/debian $CODENAME-backports non-free
 EOF
 
-if [[ -n $TRANSITION_NO_TURNKEY_APT_REPO ]]; then
+if [[ -n "$NO_TURNKEY_APT_REPO" ]]; then
     find $SOURCES_LIST -type f -exec sed -i '/archive.turnkeylinux.org/ s/^/#/g' {} \;
 fi
 
@@ -168,9 +185,13 @@ Package: php-common
 Pin: origin packages.sury.org
 Pin-Priority: 550
 
-Package: *
+Package: libpcre2-8-0
 Pin: origin packages.sury.org
-Pin-Priority: 10
+Pin-Priority: 550
+
+Package: libgd3
+Pin: origin packages.sury.org
+Pin-Priority: 550
 
 # only enable below if using latest php version
 #Package: php-imagick
@@ -188,6 +209,9 @@ Pin-Priority: 10
 EOF
     # dynamically add some extra pins as specified in appliance Makefile
     for package_name in $PHP_EXTRA_PINS; do
+        if grep -q "Package: $package_name" /etc/apt/preferences.d/php-sury.pref; then
+            continue
+        fi
         cat >> /etc/apt/preferences.d/php-sury.pref <<EOF
 Package: $package_name
 Pin: origin packages.sury.org

--- a/conf/bootstrap_apt
+++ b/conf/bootstrap_apt
@@ -2,8 +2,8 @@
 
 # create apt sources
 # environment variables:
-#   - CODENAME <required>:
-#       - OS codename to use
+#   - RELEASE <required>:
+#       - OS distro and codename to use (e.g. 'debian/bookworm')
 #   - NONFREE <optional>:
 #       - set to enable non-free by default
 #   - TKL_TESTING <optional>:
@@ -34,8 +34,9 @@ fatal() {
     exit 1
 }
 
-[ -n "$CODENAME" ] || fatal "CODENAME is not set"
 [ ! -f /turnkey-buildenv ] || source /turnkey-buildenv
+[ -n "$RELEASE" ] || fatal "RELEASE is not set"
+CODENAME=$(basename $RELEASE)
 rm -rf /turnkey-buildenv
 
 SOURCES_LIST=/etc/apt/sources.list.d

--- a/conf/bootstrap_apt
+++ b/conf/bootstrap_apt
@@ -46,19 +46,21 @@ mkdir -p $SOURCES_LIST $PREFS_LIST $CONF_DIR
 
 # transition - add specific Debian base transition changes here
 deb_ver=$(sed -nE "s|^([0-9]+).*|\1|p" /etc/debian_version)
-if [[ -n "$HOST_DEB_VER" ]] && [[ "$HOST_DEB_VER" != "$deb_ver" ]]; then
+[[ -n "$HOST_DEB_VER" ]] || HOST_DEB_VER=$deb_ver
+if [[ "$HOST_DEB_VER" != "$deb_ver" ]]; then
     echo "# Transition build detected - building v$deb_ver on v$HOST_DEB_VER"
     if [[ $HOST_DEB_VER -ne $((deb_ver - 1)) ]]; then
         fatal "Detected more than one Debian major version difference"
     elif [[ $deb_ver -lt 9 ]]; then
         fatal "Debian releases older than Stretch no longer supported"
-    elif [[ $deb_ver -le 10 ]]; then
-        sec_repo="$CODENAME/updates"
-        PROXY_PORT=8124
-    elif [[ $deb_ver -ge 11 ]]; then
-        sec_repo="$CODENAME-security"
-        PROXY_PORT=3128
     fi
+fi
+if [[ $deb_ver -le 10 ]]; then
+    sec_repo="$CODENAME/updates"
+    PROXY_PORT=8124
+elif [[ $deb_ver -ge 11 ]]; then
+    sec_repo="$CODENAME-security"
+    PROXY_PORT=3128
 fi
 
 if [[ "${APT_PROXY_OVERRIDE,,}" -eq "disable" ]]; then

--- a/plans/boot
+++ b/plans/boot
@@ -10,6 +10,7 @@ live-boot                   /* live-boot replaces casper in v16.x */
 live-tools                  /* live tools provides additional tools for live booting */
 live-boot-initramfs-tools
 initramfs-tools
+zstd                        /* recommended (new bookworm default) initramfs compression */
 firmware-linux-free
 busybox
 

--- a/plans/turnkey/base
+++ b/plans/turnkey/base
@@ -5,7 +5,6 @@
 wget
 curl
 rsync
-zstd                    /* recommended (new default) initramfs compression */
 
 di-live
 whiptail                /* di-live recommends */
@@ -24,7 +23,7 @@ resolvconf              /* confconsole recommends */
 /* seed entropy in early boot (especially useful when live booting).       */
 jitterentropy-rngd
 
-//tklbam                  /* still depends on py2 for now */
+tklbam                  /* still depends on py2 for now */
 
 hubdns
 inithooks
@@ -35,7 +34,7 @@ turnkey-version
 cron
 cron-apt
 
-etckeeper               /* still depends on py2 for now */
+etckeeper
 git
 
 lsb-release
@@ -63,7 +62,7 @@ webmin-custom
 webmin-fdisk
 webmin-raid
 webmin-lvm
-//webmin-tklbam
+webmin-tklbam
 webmin-updown
 webmin-filemin
 fdisk                   /* webmin-fdisk recommends */

--- a/plans/turnkey/base
+++ b/plans/turnkey/base
@@ -5,6 +5,7 @@
 wget
 curl
 rsync
+zstd                    /* recommended (new default) initramfs compression */
 
 di-live
 whiptail                /* di-live recommends */


### PR DESCRIPTION
First commit is a minor change to include new default initramfs compression tool (`zstd`).

The next 2 contain a fair bit of refactoring to `conf/bootstrap_apt` for bookworm (with intention to create minimal regressions for earlier releases now and in future).

- more detailed info re env vars (comments at top of script)
- require `RELEASE` (not `CODENAME` as it was previously)
- mechanism to pre-seed env vars via `/turnkey-buildenv` env file (each line should be `export ENVAR_KEY=value`)
- refactor previous release specific tweaks - to make it future transitions easier
- define `DEBIAN_PHP_V` programmatically (as it should have been before...)
- refactor @OnGle's work to use env var `NO_TURNKEY_APT_REPO` (via env var file `/turnkey-buildenv`)
- remove duplicate PHP pin for `*` in default Sury PHP config
- move consistent `PHP_EXTRA_PINS` packages to default Sury PHP config
- only add `PHP_EXTRA_PINS` if they don't already exist in default Sury PHP config

Note related to / required by: https://github.com/turnkeylinux/buildroot/pull/7