### PR TITLE
More 18.x fixes/improvements

### DIFF
--- a/conf/turnkey.d/fail2ban-fixes
+++ b/conf/turnkey.d/fail2ban-fixes
@@ -1,8 +1,5 @@
 #!/bin/bash -e
 
-# make fail2ban default to reading journal - see #1844 (Debian #1037437)
-sed -i "\|^backend = auto|s|auto|systemd|" /etc/fail2ban/jail.conf
-
 # ensure that fail2ban blocks known users with incorrect key - see Debian
 # Bug #1038779 - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1038779
 cd /etc

--- a/conf/turnkey.d/fail2ban-fixes
+++ b/conf/turnkey.d/fail2ban-fixes
@@ -3,6 +3,45 @@
 # make fail2ban default to reading journal - see #1844 (Debian #1037437)
 sed -i "\|^backend = auto|s|auto|systemd|" /etc/fail2ban/jail.conf
 
+# ensure that fail2ban blocks known users with incorrect key - see Debian
+# Bug #1038779 - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1038779
+cd /etc
+cat > fail2ban.patch <<EOF
+diff --git a/fail2ban/filter.d/sshd.conf b/fail2ban/filter.d/sshd.conf
+index d5d189b..e48f2ae 100644
+--- a/fail2ban/filter.d/sshd.conf
++++ b/fail2ban/filter.d/sshd.conf
+@@ -97,9 +97,9 @@ publickey = nofail
+ # consider failed publickey for invalid users only:
+ cmnfailre-failed-pub-invalid = ^Failed publickey for invalid user <F-USER>(?P<cond_user>\S+)|(?:(?! from ).)*?</F-USER> from <HOST>%(__on_port_opt)s(?: ssh\d*)?(?(cond_user): |(?:(?:(?! from ).)*)$)
+ # consider failed publickey for valid users too (don't need RE, see cmnfailed):
+-cmnfailre-failed-pub-any =
++cmnfailre-failed-pub-any = ^Failed publickey for <F-USER>(?P<cond_user>\S+)|(?:(?! from ).)*?</F-USER> from <HOST>%(__on_port_opt)s(?: ssh\d*)?(?(cond_user): |(?:(?:(?! from ).)*)$)
+ # same as invalid, but consider failed publickey for valid users too, just as no failure (helper to get IP and user-name only, see cmnfailed):
+-cmnfailre-failed-pub-nofail = <cmnfailre-failed-pub-invalid>
++cmnfailre-failed-pub-nofail = <cmnfailre-failed-pub-any>
+ # don't consider failed publickey as failures (don't need RE, see cmnfailed):
+ cmnfailre-failed-pub-ignore =
+EOF
+git apply fail2ban.patch
+rm fail2ban.patch
+cd -
+
+cat > /etc/cron.weekly/fail2ban <<EOF
+#!/bin/sh
+#
+# Periodically vacuum database to prevent it growing endlessly- see Debian
+# Bug #1010011 - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1010011
+
+sqlite="/usr/bin/sqlite3"
+database="/var/lib/fail2ban/fail2ban.sqlite3"
+
+[ -x $sqlite ] && [ -f $database ] || exit 0
+
+$sqlite $database "VACUUM;"
+EOF
+chmod +x /etc/cron.weekly/fail2ban
+
 # On firstboot (especially live) a race condition can occur where the auth.log
 # does not exist (yet) when fail2ban tries to start; which causes it to fail.
 # So make sure it exists:

--- a/conf/turnkey.d/fail2ban-fixes
+++ b/conf/turnkey.d/fail2ban-fixes
@@ -1,5 +1,13 @@
 #!/bin/bash -e
 
+# explictly allow ipv6 - see Debian bug #1024305:
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1024305
+
+CONF=/etc/fail2ban/fail2ban.conf
+if ! grep -q '^allowipv6' $CONF; then
+    sed -i '\|^\[Definition\]|a \\nallowipv6 = auto' $CONF
+fi
+
 # ensure that fail2ban blocks known users with incorrect key - see Debian
 # Bug #1038779 - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1038779
 cd /etc

--- a/conf/turnkey.d/postfix-local
+++ b/conf/turnkey.d/postfix-local
@@ -29,4 +29,5 @@ postconf -e tls_medium_cipherlist="ZZ_SSL_CIPHERS"
 postconf -e tls_preempt_cipherlist=no
 
 service postfix start
+systemctl enable --now postfix@-.service
 service postfix stop

--- a/overlays/turnkey.d/fail2ban/etc/fail2ban/jail.local
+++ b/overlays/turnkey.d/fail2ban/etc/fail2ban/jail.local
@@ -1,0 +1,24 @@
+# fail2ban default config provided by TurnKey
+#
+# This is a work in progress and currently only provides marginal improvement
+# beyond Debian default.
+#
+# To help out, please see:
+# https://github.com/turnkeylinux/tracker/issues/1022
+
+[DEFAULT]
+ignoreip    = 127.0.0.1/8 ::1  
+bantime     = 3600
+findtime    = 10
+maxretry    = 2
+backend     = systemd
+
+[sshd]
+enabled     = true
+port        = ssh,22
+action      = iptables[name=SSH, port=22, protocol=tcp]
+
+[webmin-auth]
+enabled     = true
+port        = 12321
+action      = iptables[name=webmin, port=12321, protocol=tcp]

--- a/overlays/turnkey.d/sshd/etc/ssh/sshd_config.d/turnkey.conf
+++ b/overlays/turnkey.d/sshd/etc/ssh/sshd_config.d/turnkey.conf
@@ -1,22 +1,11 @@
-#!/bin/bash -e
+# SSh daemon config supplied by TurnKey
+# given default config; this overrides default values in /etc/ssh/sshd_config
 
 # permit root ssh login with password
-sed -i "/^PermitRootLogin/ s/without-password/yes/" /etc/ssh/sshd_config
+PermitRootLogin yes
 
 # disable sshd dns checks (if resolution fails will prevent logins)
-echo "UseDNS no" >> /etc/ssh/sshd_config
-
-# harden ssh daemon
-sed -i '{
-  /^X11Forwarding/ d
-  /^TCPKeepAlive/ d
-  /^AllowTcpForwarding/ d
-  /^ClientAliveCountMax/ d
-  /^MaxAuthTries/ d
-  /^MaxSessions/ d
-}' /etc/ssh/sshd_config
-
-cat >> /etc/ssh/sshd_config <<EOF
+UseDNS no
 
 # https://github.com/turnkeylinux/tracker/issues/1092
 TCPKeepAlive yes
@@ -27,12 +16,8 @@ AllowTcpForwarding no
 ClientAliveCountMax 2
 MaxAuthTries 3
 MaxSessions 2
-EOF
 
 # configure root login banner directive (enabled by inithooks#sudoadmin)
-cat >> /etc/ssh/sshd_config <<EOF
-
 Match user root
 Banner /root/.ssh/banner
 Match user *
-EOF

--- a/plans/turnkey/base
+++ b/plans/turnkey/base
@@ -77,6 +77,7 @@ iptables
 webmin-firewall
 webmin-firewall6
 fail2ban
+python3-systemd         /* fail2ban recommends - required for fail2ban without rsyslog */
 webmin-fail2ban
 
 ssh


### PR DESCRIPTION
`fail2ban`
- provide default `jail.local` config file (rather than changing Debian supplied `jail.conf`)
- install `python3-systemd` package - finalises https://github.com/turnkeylinux/tracker/issues/1843, https://github.com/turnkeylinux/tracker/issues/1844 & https://github.com/turnkeylinux/tracker/issues/1850
- block known users using wrong keys
- weekly vacuum DB to keep filesize down
- explicitly set `allowipv6 = auto` (quiet logs - otherwise is warning is logged)

`postfix`
- ensure `postfix` starts

`sshd`
- replace common `sshd` conf script with conf file overlay (`/etc/ssh/sshd_config.d/turnkey.conf`) - improved user experience when upgrading ssh (not changing default config file will avoid asking user if/when default config file updated)