### PR TITLE
Disabling protocols for security hardening

### DIFF
--- a/overlays/turnkey.d/protocol-hardening/etc/modprobe.d/dccp.conf
+++ b/overlays/turnkey.d/protocol-hardening/etc/modprobe.d/dccp.conf
@@ -1,0 +1,1 @@
+install dccp /bin/true

--- a/overlays/turnkey.d/protocol-hardening/etc/modprobe.d/rds.conf
+++ b/overlays/turnkey.d/protocol-hardening/etc/modprobe.d/rds.conf
@@ -1,0 +1,1 @@
+install rds bin/true

--- a/overlays/turnkey.d/protocol-hardening/etc/modprobe.d/sctp.conf
+++ b/overlays/turnkey.d/protocol-hardening/etc/modprobe.d/sctp.conf
@@ -1,0 +1,1 @@
+install sctp /bin/true

--- a/overlays/turnkey.d/protocol-hardening/etc/modprobe.d/tipc.conf
+++ b/overlays/turnkey.d/protocol-hardening/etc/modprobe.d/tipc.conf
@@ -1,0 +1,1 @@
+install tipc /bin/true


### PR DESCRIPTION
Disabled tipc, dccp, sctp, and rds in common/turnkey.d/overlays to reduce the attack surface of all TKL appliances.