### PR TITLE
18.x common tweaks

### DIFF
--- a/changes/apache.changelog
+++ b/changes/apache.changelog
@@ -1,0 +1,4 @@
+apache-18.0 (1) turnkey; urgency=low
+
+  * Include and enable mod_evasive and mod_security2.
+    [ Stefan Davis <stefan@turnkeylinux.org> ]

--- a/changes/composer.changelog
+++ b/changes/composer.changelog
@@ -1,0 +1,4 @@
+composer-18.0
+
+  * Install composer from Debian repos (previously installed from source)
+    [ Stefan Davis <Stefan@turnkeylinux.org> ]

--- a/changes/pgsql.changelog
+++ b/changes/pgsql.changelog
@@ -1,0 +1,7 @@
+pgsql-18.0 (1) turnkey; urgency=low
+
+  * Use postgresql 15 (from debian repos).
+    [ Stefan Davis <stefan@turnkeylinux.org> ]
+
+  * Upstream/Debian Adminer update - closes #1758.
+    [ Stefan Davis <stefan@turnkeylinux.org> ]

--- a/changes/php.changelog
+++ b/changes/php.changelog
@@ -1,0 +1,4 @@
+
+php-18.0
+
+  * Debian default PHP updated to v8.2.

--- a/changes/turnkey.changelog
+++ b/changes/turnkey.changelog
@@ -1,0 +1,70 @@
+turnkey-core-18.0 (1) turnkey; urgency=low
+
+  * Upgraded base distribution to Debian 12.x/Bullseye.
+
+  * Configuration console (confconsole):
+
+    - Support for DNS-01 Let's Encrypt challenges.
+      [ Oleh Dmytrychenko <dmytrychenko.oleh@gmail.com> github: @NitrogenUA ]
+    - Support for getting Let's Encrypt cert via IPv6 - closes #1785.
+    - Refactor network interface code to ensure that it works as expected and
+      supports more possible network config (e.g. hotplug interfaces & wifi).
+    - Show error message rather than stacktrace when window resized to
+      incompatable resolution - closes  #1609.
+      [ Stefan Davis <stefan@turnkeylinux.org> ]
+    - Bugfix exception when quitting configuration of mail relay.
+      [ Oleh Dmytrychenko <dmytrychenko.oleh@gmail.com> github: @NitrogenUA ]
+    - Improve code quality: implement typing, fstrings and make (mostly) PEP8
+      compliant.
+      [Stefan Davis <stefan@turnkeylinux.org> & Jeremy Davis
+
+  * Firstboot Initialization (inithooks):
+
+    - Refactor start up (now hooks into getty process, rather than having it's
+      own service).
+      [ Stefan Davis <stefan@turnkeylinux.org> ]
+    - Refactor firstboot.d/01ipconfig (and 09hostname) to ensure that hostname
+      is included in dhcp info when set via inithooks.
+    - Package turnkey-make-ssl-cert script (from common overlay - now packaged
+      as turnkey-ssl). Refactor relevant scripts to leverage turnkey-ssl.
+    - Refactor run script - use bashisms and general tidying.
+    - Show blacklisted password characters more nicely.
+    - Misc packaging changes/improvements.
+    - Support returning output from MySQL - i.e. support 'SELECT'. (Only
+      applies to apps that include MySQL/MariaDB).
+
+  * Web management console (webmin):
+
+    - Upgraded webmin to v2.0.21.
+    - Removed stunnel reverse proxy (Webmin hosted directly now).
+    - Ensure that Webmin uses HTTPS with default cert
+      (/etc/ssl/private/cert.pem).
+    - Disabled Webmin Let's Encrypt (for now).
+
+  * Web shell (shellinabox):
+
+    - Completely removed in v18.0 (Webmin now has a proper interactive shell).
+
+  * Backup (tklbam):
+
+    - Ported dependencies to Debian Bookworm; otherwise unchanged.
+
+  * Security hardening & improvements:
+
+    - Generate and use new TurnKey Bookworm keys.
+    - Automate (and require) default pinning for packages from Debian
+      backports. Also support non-free backports.
+
+  * IPv6 support:
+    - Adminer (only on LAMP based apps) listen on IPv6.
+    - Nginx/NodeJS (NodeJS based apps only) listen on IPv6.
+
+  * Misc bugfixes & feature implementations:
+
+    - Remove rsyslog package (systemd journal now all that's needed).
+    - Include zstd compression support.
+    - Enable new non-free-firmware apt repo by default.
+    - Improve turnkey-artisan so that it works reliably in cron jobs (only
+      Laravel based LAMP apps).
+
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Wed, 12 Jul 2023 01:23:34 +0000

--- a/conf/turnkey.d/postfix-local
+++ b/conf/turnkey.d/postfix-local
@@ -29,5 +29,5 @@ postconf -e tls_medium_cipherlist="ZZ_SSL_CIPHERS"
 postconf -e tls_preempt_cipherlist=no
 
 service postfix start
-systemctl enable --now postfix@-.service
+systemctl enable postfix@-.service
 service postfix stop

--- a/overlays/composer/usr/local/bin/turnkey-composer
+++ b/overlays/composer/usr/local/bin/turnkey-composer
@@ -15,19 +15,17 @@ fatal() { echo "FATAL: $@" >&2; exit 1; }
 [[ "$(id -u)" -eq 0 ]] \
     || fatal "$(basename $0) must be run as root, please re-run with sudo"
 
-export COMPOSER_USER="${COMPOSER_USER:-www-data}"
-export COMPOSER_USER_HOME=$(getent passwd $COMPOSER_USER | cut -d: -f6) || true
-export APP_ROOT="${APP_ROOT:-none}"
-
 if [[ -n "$COMPOSER_USER" ]] && [[ -n "$COMPOSER_USER_HOME"  ]]; then
     export COMPOSER_HOME="${COMPOSER_HOME:-$COMPOSER_USER_HOME/.composer}"
+else
+    fatal "unset env var(s): COMPOSER_USER='$COMPOSER_USER'"\
+          " COMPOSER_USER_HOME='$COMPOSER_USER_HOME'"
 fi
 
 if [[ ! -e "$COMPOSER_HOME" ]]; then
     mkdir -p $COMPOSER_HOME
 elif [[ ! -d "$COMPOSER_HOME" ]]; then
-    echo "Fatal: COMPOSER_HOME ($COMPOSER_HOME) exists but is a file."
-    exit 1
+    fatal "COMPOSER_HOME ($COMPOSER_HOME) exists but is a file"
 fi
 chown -R $COMPOSER_USER:$COMPOSER_USER $COMPOSER_HOME
 
@@ -47,6 +45,10 @@ Env vars::
                         Default: $COMPOSER_USER
     COMPOSER_USER_HOME  Home directory to use when running Composer
                         Default: $COMPOSER_USER_HOME
+    COMPOSER_MEMORY_LIMIT
+                        Composer memory limit (handled by composer)
+    HTTPS_PROXY_REQUEST_FULLURI
+                        Proxy to use for downloads (handled by composer)
     APP_ROOT            Directory to run composer in
                         - if set to 'none', will run in cwd
                         - if dir does not exist it will be ignored

--- a/overlays/composer/usr/local/bin/turnkey-composer
+++ b/overlays/composer/usr/local/bin/turnkey-composer
@@ -1,9 +1,23 @@
 #!/bin/bash -e
 
+# fallback defaults - adjust as desired
+USER_FALLBACK=www-data
+HOME_FALLBACK=/var/www
+APP_ROOT_FALLBACK=none
+
+export COMPOSER_USER="${COMPOSER_USER:-$USER_FALLBACK}"
+export COMPOSER_USER_HOME="${COMPOSER_USER_HOME:-$HOME_FALLBACK}"
+export APP_ROOT="${APP_ROOT:-$APP_ROOT_FALLBACK}"
+
+fatal() { echo "FATAL: $@" >&2; exit 1; }
+
 [[ -z "$DEBUG" ]] || set -x
+[[ "$(id -u)" -eq 0 ]] \
+    || fatal "$(basename $0) must be run as root, please re-run with sudo"
 
 export COMPOSER_USER="${COMPOSER_USER:-www-data}"
 export COMPOSER_USER_HOME=$(getent passwd $COMPOSER_USER | cut -d: -f6) || true
+export APP_ROOT="${APP_ROOT:-none}"
 
 if [[ -n "$COMPOSER_USER" ]] && [[ -n "$COMPOSER_USER_HOME"  ]]; then
     export COMPOSER_HOME="${COMPOSER_HOME:-$COMPOSER_USER_HOME/.composer}"
@@ -17,10 +31,39 @@ elif [[ ! -d "$COMPOSER_HOME" ]]; then
 fi
 chown -R $COMPOSER_USER:$COMPOSER_USER $COMPOSER_HOME
 
+if [[ "$1" == '-h' ]] || [[ "$1" == '--help' ]]; then
+    cat <<EOF
+Syntax $(basename $0) [-h|--help] <composer_command>
+
+Run <composer_command> as an alternate user, in the pre-defined webroot.
+
+To adjust defaults, please edit the "fallback defaults" at the top of this
+script. You can find it at '$(realpath $0)'
+
+Env vars::
+----------
+
+    COMPOSER_USER       User to run commands as
+                        Default: $COMPOSER_USER
+    COMPOSER_USER_HOME  Home directory to use when running Composer
+                        Default: $COMPOSER_USER_HOME
+    APP_ROOT            Directory to run composer in
+                        - if set to 'none', will run in cwd
+                        - if dir does not exist it will be ignored
+                        Default: $APP_ROOT
+    DEBUG               Set to enable verbose output - useful for debugging
+EOF
+    exit 1
+fi
+
 ENV="COMPOSER_HOME=$COMPOSER_HOME"
 [[ -z "$COMPOSER_MEMORY_LIMIT" ]] || ENV="$ENV COMPOSER_MEMORY_LIMIT=$COMPOSER_MEMORY_LIMIT"
 [[ -z "$HTTPS_PROXY_REQUEST_FULLURI" ]] || ENV="$ENV HTTPS_PROXY_REQUEST_FULLURI=$HTTPS_PROXY_REQUEST_FULLURI"
 
-COMMAND="composer"
+if [[ "$APP_ROOT" != "none" ]] && [[ -d "$APP_ROOT" ]]; then
+    COMMAND="cd $APP_ROOT && $ENV composer"
+else
+    COMMAND="$ENV composer"
+fi
 
-runuser $COMPOSER_USER -s /bin/bash -c "$ENV $COMMAND $(printf '%q ' "$@")"
+runuser $COMPOSER_USER -s /bin/bash -c "$COMMAND $(printf '%q ' "$@")"

--- a/overlays/composer/usr/local/bin/turnkey-composer
+++ b/overlays/composer/usr/local/bin/turnkey-composer
@@ -1,71 +1,26 @@
 #!/bin/bash -e
 
-# fallback defaults - adjust as desired
-USER_FALLBACK=www-data
-HOME_FALLBACK=/var/www
-APP_ROOT_FALLBACK=none
-
-export COMPOSER_USER="${COMPOSER_USER:-$USER_FALLBACK}"
-export COMPOSER_USER_HOME="${COMPOSER_USER_HOME:-$HOME_FALLBACK}"
-export APP_ROOT="${APP_ROOT:-$APP_ROOT_FALLBACK}"
-
-fatal() { echo "FATAL: $@" >&2; exit 1; }
-
 [[ -z "$DEBUG" ]] || set -x
-[[ "$(id -u)" -eq 0 ]] \
-    || fatal "$(basename $0) must be run as root, please re-run with sudo"
+
+export COMPOSER_USER="${COMPOSER_USER:-www-data}"
+export COMPOSER_USER_HOME=$(getent passwd $COMPOSER_USER | cut -d: -f6) || true
 
 if [[ -n "$COMPOSER_USER" ]] && [[ -n "$COMPOSER_USER_HOME"  ]]; then
     export COMPOSER_HOME="${COMPOSER_HOME:-$COMPOSER_USER_HOME/.composer}"
-else
-    fatal "unset env var(s): COMPOSER_USER='$COMPOSER_USER'"\
-          " COMPOSER_USER_HOME='$COMPOSER_USER_HOME'"
 fi
 
 if [[ ! -e "$COMPOSER_HOME" ]]; then
     mkdir -p $COMPOSER_HOME
 elif [[ ! -d "$COMPOSER_HOME" ]]; then
-    fatal "COMPOSER_HOME ($COMPOSER_HOME) exists but is a file"
-fi
-chown -R $COMPOSER_USER:$COMPOSER_USER $COMPOSER_HOME
-
-if [[ "$1" == '-h' ]] || [[ "$1" == '--help' ]]; then
-    cat <<EOF
-Syntax $(basename $0) [-h|--help] <composer_command>
-
-Run <composer_command> as an alternate user, in the pre-defined webroot.
-
-To adjust defaults, please edit the "fallback defaults" at the top of this
-script. You can find it at '$(realpath $0)'
-
-Env vars::
-----------
-
-    COMPOSER_USER       User to run commands as
-                        Default: $COMPOSER_USER
-    COMPOSER_USER_HOME  Home directory to use when running Composer
-                        Default: $COMPOSER_USER_HOME
-    COMPOSER_MEMORY_LIMIT
-                        Composer memory limit (handled by composer)
-    HTTPS_PROXY_REQUEST_FULLURI
-                        Proxy to use for downloads (handled by composer)
-    APP_ROOT            Directory to run composer in
-                        - if set to 'none', will run in cwd
-                        - if dir does not exist it will be ignored
-                        Default: $APP_ROOT
-    DEBUG               Set to enable verbose output - useful for debugging
-EOF
+    echo "Fatal: COMPOSER_HOME ($COMPOSER_HOME) exists but is a file."
     exit 1
 fi
+chown -R $COMPOSER_USER:$COMPOSER_USER $COMPOSER_HOME
 
 ENV="COMPOSER_HOME=$COMPOSER_HOME"
 [[ -z "$COMPOSER_MEMORY_LIMIT" ]] || ENV="$ENV COMPOSER_MEMORY_LIMIT=$COMPOSER_MEMORY_LIMIT"
 [[ -z "$HTTPS_PROXY_REQUEST_FULLURI" ]] || ENV="$ENV HTTPS_PROXY_REQUEST_FULLURI=$HTTPS_PROXY_REQUEST_FULLURI"
 
-if [[ "$APP_ROOT" != "none" ]] && [[ -d "$APP_ROOT" ]]; then
-    COMMAND="cd $APP_ROOT && $ENV composer"
-else
-    COMMAND="$ENV composer"
-fi
+COMMAND="composer"
 
-runuser $COMPOSER_USER -s /bin/bash -c "$COMMAND $(printf '%q ' "$@")"
+runuser $COMPOSER_USER -s /bin/bash -c "$ENV $COMMAND $(printf '%q ' "$@")"

--- a/overlays/turnkey.d/container-tweaks/etc/systemd/system/jitterentropy.service.d/override.conf
+++ b/overlays/turnkey.d/container-tweaks/etc/systemd/system/jitterentropy.service.d/override.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionVirtualization=!container

--- a/overlays/turnkey.d/systemd-chroot/usr/local/bin/service
+++ b/overlays/turnkey.d/systemd-chroot/usr/local/bin/service
@@ -15,11 +15,13 @@ stop_start() {
 
     case $_action in
         stop|restart)
-            pid=$(pgrep $_service)
+            pid=$(pgrep $_service) || true
             if [[ "$_service" == "ghost" ]]; then
                 pid="$pid $(pgrep node) $(pgrep sudo)"
+            elif [[ "$_service" == "webmin" ]]; then
+                pid="$(pgrep miniserv.pl)"
             fi
-            kill -9 $pid
+            kill $pid
             ;;&
         start|restart)
             $_command
@@ -35,6 +37,12 @@ stop_start() {
 }
 
 case $1 in
+
+    webmin)
+        export PERLLIB=/usr/share/webmin
+        stop_start $2 $1 \
+            /usr/share/webmin/miniserv.pl /etc/webmin/miniserv.conf
+        ;;
 
     apache2)
         if [[ $2 == "reload" ]]; then

--- a/plans/turnkey/base
+++ b/plans/turnkey/base
@@ -70,8 +70,6 @@ unzip                   /* webmin-updown recommends */
 libfile-mimeinfo-perl   /* webmin-filemin requires to extract archives */
 
 logrotate
-rsyslog
-webmin-syslog
 
 iptables
 webmin-firewall


### PR DESCRIPTION
[update] Note `turnkey-composer` updates have been spilt off into their own PR - see #272 

Also, whilst the PR notes changes to `turnkey-php` that no longer appears to be the case...

----

<s>Make turnkey-composer better:
- add `-h|--help` arg
- make fallback defaults more obvious and more easily configured by end user
- support setting `APPROOT` (default cwd to run composer)

The intention is that when used in a specific appliance, the `APPR_FALLBACK` is updated to be the application root dir (and other defaults as relevant - mostly won't need to be touched).</s>

<s>And added some other</s> random tweaks:
- minor tweak to postfix config (just avoids warning message) - https://github.com/turnkeylinux/common/pull/266/commits/c346c92c18384b0f38ded6693ebb8588646cb8b3
- <s>improve `turnkey-php` - https://github.com/turnkeylinux/common/pull/266/commits/1de09576981c5b092ca42083a63914612460ca80</s>
- Add Core v18.0 changelog to common (`changes/turnkey.changelog`) - https://github.com/turnkeylinux/common/pull/266/commits/31314f23735e3eb1e7e818f185eefcff4bc8110b
- improve `service` wrapper script (include webmin & kill cleanly) - https://github.com/turnkeylinux/common/pull/266/commits/4db2633971ef9490f866072b88cb0c80d3d647d5