### PR TITLE
Configure mod_evasive log location

### DIFF
--- a/changes/apache.changelog
+++ b/changes/apache.changelog
@@ -1,5 +1,8 @@
 turnkey-apache-18.0 (1) turnkey; urgency=low
 
+  * Set mod_evasive log location - makes debugging easier.
+    [ Jeremy Davis <jeremy@turnkeylinux.org> ]
+
   * Include and enable mod_evasive and mod_security2 by default in Apache.
     [ Stefan Davis <Stefan@turnkeylinux.org> ]
 

--- a/conf/apache-security
+++ b/conf/apache-security
@@ -3,3 +3,9 @@
 # try to enable mod, if it's not available just continue
 a2enmod security2 || true
 a2enmod evasive || true
+
+# ensure that mod_evasive can write to log
+CONF=/etc/apache2/mods-available/evasive.conf
+if [[ -f "$CONF" ]]; then
+    sed -i '\|DOSLogDir| s|#||; \|DOSLogDir| s|".*"$|"/var/log/apache2"|' $CONF
+fi


### PR DESCRIPTION
Configure mod_evasive log location so that it can log issues (will make end user tweaks easier).