### PR TITLE
make conf/php regex more strict

### DIFF
--- a/conf/php
+++ b/conf/php
@@ -6,7 +6,7 @@ setini() {
     var=$2
     val=$3
 
-    count=$(grep -c $var $file) || true
+    count=$(grep -c "^;\?$var" $file) || true
     if [ "$count" -eq 0 ]; then
         echo "[WARNING] no match for $var in $file"
     elif [ "$count" -gt 1 ]; then


### PR DESCRIPTION
After c0732ae, conf/php would fail with PHP 8.2 since max_input_vars
occurs twice in /etc/php/8.2/apache2/php.ini. One of those matches is
just part of a comment for another variable, though.

This change also matches the grep behavior to later sed behavior in the
same script (which explicitly looks for the beginning of the line).
