### PR TITLE
Tweak gh_releases

### DIFF
--- a/overlays/turnkey.d/github-latest-release/usr/local/bin/gh_releases
+++ b/overlays/turnkey.d/github-latest-release/usr/local/bin/gh_releases
@@ -2,7 +2,6 @@
 
 [[ -z $DEBUG ]] || set -x
 
-repo_path="$1" # user/repo_name
 tmp_dir=/tmp/gh_releases
 rm -rf $tmp_dir
 mkdir -p $tmp_dir
@@ -12,14 +11,19 @@ warning() { echo -e "[WARNING] $*" 1>&2; }
 
 usage() {
     cat >&2 <<EOF
-Usage: $(basename "$0") <user>/<repo>
+Usage: $(basename "$0") [OPTIONS] <user>/<repo>
+
+Options:
+    -a|--all    show all (stable) versions, not just the most recent
+    -p|--inc-pre-release
+                include alpha, beta and rc versions
 
 Env Vars:
     # used for github api
     GITHUB_USER
     GITHUB_USER_TOKEN
 
-    # retain temp files and set x if set
+    # retain temp files and set x
     DEBUG
 
     # omit tags or releases in output respectively if set
@@ -30,6 +34,24 @@ Note: Setting GITHUB_USER and GITHUB_USER_TOKEN environment variables are
       recommended. If not set, multipage results may be unreliable.
 EOF
 }
+
+unset show_all pre_release repo_path
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -a|--all)
+            show_all=true;;
+        -p|--inc-pre-release)
+            pre_release=true;;
+        *)
+            if [[ -z "$repo_path" ]]; then
+                repo_path="$1"
+            else
+                usage
+                fatal "Unknown option: $1"
+           fi;;
+    esac
+    shift
+done
 
 if [[ -z "$repo_path" ]]; then
     usage
@@ -89,5 +111,12 @@ get_all_pages() {
 [[ -z $NO_TAGS ]] && get_all_pages "https://api.github.com/repos/${repo_path}/tags" "name"
 
 echo "Done!" 1>&2
-cat $tmp_dir/releases | sort --version-sort --unique
-[[ -n $DEBUG ]] || rm -rf $tmp_dir
+versions=$(cat $tmp_dir/releases | sort --version-sort --unique)
+if [[ -z "$pre_release" ]]; then
+    versions=$(grep -vi 'alpha\|beta\|rc' <<<"$versions")
+fi
+if [[ -z "$show_all" ]]; then
+    versions=$(tail -1 <<<"$versions")
+fi
+echo "$versions"
+[[ -z $DEBUG ]] && rm -rf $tmp_dir

--- a/overlays/turnkey.d/github-latest-release/usr/local/bin/gh_releases
+++ b/overlays/turnkey.d/github-latest-release/usr/local/bin/gh_releases
@@ -14,6 +14,7 @@ usage() {
 Usage: $(basename "$0") [OPTIONS] <user>/<repo>
 
 Options:
+    -h|--help   show this help and exit
     -a|--all    show all (stable) versions, not just the most recent
     -p|--inc-pre-release
                 include alpha, beta and rc versions
@@ -42,6 +43,9 @@ while [[ "$#" -gt 0 ]]; do
             show_all=true;;
         -p|--inc-pre-release)
             pre_release=true;;
+        -h|--help)
+            usage
+            exit;;
         *)
             if [[ -z "$repo_path" ]]; then
                 repo_path="$1"

--- a/overlays/turnkey.d/github-latest-release/usr/local/bin/gh_releases
+++ b/overlays/turnkey.d/github-latest-release/usr/local/bin/gh_releases
@@ -89,7 +89,9 @@ get_page() {
     page=$3
     tmp_file=$(mktemp $tmp_dir/XXXX.tmp)
     curl "$USER" -b /tmp/cookies.txt -c /tmp/cookies.txt -s "${url}?page=${page}&per_page=100" > "$tmp_file" 2>/dev/null || true
-    if grep '"message"' "$tmp_file"; then
+    if grep "Bad credentials" "$tmp_file" >/dev/null ; then
+        fatal "Bad GitHub credentials"
+    elif grep '"message"' "$tmp_file"; then
         fatal "$repo_path: $(sed -En '\|message|s|^.*: "(.*)",$|\1|p' "$tmp_file")"
     else
         grep -oP "\"$key\": \"\\K(.*)(?=\")" "$tmp_file"

--- a/overlays/turnkey.d/github-latest-release/usr/local/bin/gh_releases
+++ b/overlays/turnkey.d/github-latest-release/usr/local/bin/gh_releases
@@ -16,7 +16,7 @@ Usage: $(basename "$0") [OPTIONS] <user>/<repo>
 Options:
     -h|--help   show this help and exit
     -a|--all    show all (stable) versions, not just the most recent
-    -p|--inc-pre-release
+    -p|--pre-release
                 include alpha, beta and rc versions
 
 Env Vars:
@@ -41,7 +41,7 @@ while [[ "$#" -gt 0 ]]; do
     case $1 in
         -a|--all)
             show_all=true;;
-        -p|--inc-pre-release)
+        -p|--pre-release)
             pre_release=true;;
         -h|--help)
             usage


### PR DESCRIPTION
Change `gh_release` default behaviour to only show latest stable by default, also removing pre-release versions (assuming that they contain `alpha`|`beta`|`rc` keywords) from the output. Previous behaviour can still be obtained via `gh_release --all --pre-release <user>/<repo>`:

```
Usage: gh_releases [OPTIONS] <user>/<repo>

Options:
    -h|--help   show this help and exit
    -a|--all    show all (stable) versions, not just the most recent
    -p|--pre-release
                include alpha, beta and rc versions

Env Vars:
    # used for github api
    GITHUB_USER
    GITHUB_USER_TOKEN

    # retain temp files and set x
    DEBUG

    # omit tags or releases in output respectively if set
    NO_TAGS
    NO_RELEASES

Note: Setting GITHUB_USER and GITHUB_USER_TOKEN environment variables are
      recommended. If not set, multipage results may be unreliable.
```
