### PR TITLE
systemd-chroot: fix buggy service wrapper script

### DIFF
--- a/overlays/turnkey.d/systemd-chroot/usr/local/bin/service
+++ b/overlays/turnkey.d/systemd-chroot/usr/local/bin/service
@@ -5,26 +5,35 @@
 # Should deal with common build time calls to "service" with common actions
 # If the service isn't recognised, then will fall back to /usr/bin/service
 
-
 stop_start() {
-    _action=$1 # stop|start|restart
+    _action="$1" # stop|start|restart
     shift
-    _service=$1 # service name - only used with stop|restart
+    _service="$1" # service name - only used with stop|restart
     shift
-    _command="$@" # command to run - only used with start|restart
+    _command="$*" # command to run - only used with start|restart
 
     case $_action in
         stop|restart)
-            pid=$(pgrep $_service) || true
-            if [[ "$_service" == "ghost" ]]; then
-                pid="$pid $(pgrep node) $(pgrep sudo)"
-            elif [[ "$_service" == "webmin" ]]; then
-                pid="$(pgrep miniserv.pl)"
+            if pid="$(pgrep "$_service")"; then
+                if [[ "$_service" == "ghost" ]]; then
+                    pid="$pid $(pgrep node) $(pgrep sudo)"
+                elif [[ "$_service" == "webmin" ]]; then
+                    pid="$(pgrep miniserv.pl)"
+                fi
+                kill "$pid"
+            else
+                # it's stopped, technically…
+                echo "WARNING: stop_start could not find pid for $_service!"
             fi
-            kill $pid
             ;;&
         start|restart)
-            $_command
+            # this should background processes that do not background themselves
+            # while doing no harm where the process does background itself
+            $_command & pid=$!
+            # poke it to see if it's alive after 1s
+            # if not, reap and fail
+            sleep 1
+            kill -0 "$pid" || { wait; return 1; }
             ;;
         stop)
             # catch stop after 'stop|restart' falls through
@@ -36,27 +45,26 @@ stop_start() {
     esac
 }
 
-case $1 in
-
+case "$1" in
     webmin)
         export PERLLIB=/usr/share/webmin
-        stop_start $2 $1 \
+        stop_start "$2" "$1" \
             /usr/share/webmin/miniserv.pl /etc/webmin/miniserv.conf
         ;;
 
     apache2)
-        if [[ $2 == "reload" ]]; then
+        if [[ "$2" == "reload" ]]; then
             APACHE_STARTED_BY_SYSTEMD=y /usr/sbin/apache2ctl restart
         else
-            APACHE_STARTED_BY_SYSTEMD=y /usr/sbin/apache2ctl $2
+            APACHE_STARTED_BY_SYSTEMD=y /usr/sbin/apache2ctl "$2"
         fi
         ;;
 
     mysql|mariadb)
         if [[ -f /etc/init.d/mariadb ]]; then
-            /etc/init.d/mariadb $2
+            /etc/init.d/mariadb "$2"
         elif [[ -f /etc/init.d/mysql ]]; then
-            /etc/init.d/mysql $2
+            /etc/init.d/mysql "$2"
         else
             echo "No mariadb or mysql init script found" >&2
             exit 1
@@ -68,32 +76,32 @@ case $1 in
         ;;
 
     odoo)
-        stop_start $1 $2 \
-            runuser odoo -s /bin/bash -c "/usr/bin/odoo --config /etc/odoo/odoo.conf --logfile /var/log/odoo/odoo-server.log &"
+        stop_start "$2" "$1" \
+            runuser odoo -s /bin/bash -c "/usr/bin/odoo --config /etc/odoo/odoo.conf --logfile /var/log/odoo/odoo-server.log"
         ;;
 
     gitlab-runsvdir*)
-        stop_start $1 $2 \
-            /opt/gitlab/embedded/bin/runsvdir-start &
+        stop_start "$2" "$1" \
+            /opt/gitlab/embedded/bin/runsvdir-start
         ;;
 
     ghost)
-        stop_start $1 $2 \
-            cd /opt/ghost; sudo -u ghost /usr/local/bin/node /usr/local/bin/ghost start &
+        stop_start "$2" "$1" \
+            cd /opt/ghost; sudo -u ghost /usr/local/bin/node /usr/local/bin/ghost start
         ;;
 
     mattermost)
-        stop_start $1 $2 \
-            /opt/mattermost/bin/mattermost &
+        stop_start "$2" "$1" \
+            /opt/mattermost/bin/mattermost
         ;;
 
     redis)
-        stop_start $1 $2 \
-            runuser www-data -s /bin/bash -c "/usr/sbin/php-fpm?.? --daemonize --fpm-config /etc/php/*.*/fpm/php-fpm.conf"
+        stop_start "$2" "$1" \
+            runuser www-data -s /bin/bash -c "/usr/sbin/php-fpm?.? --daemonize --fpm-config /etc/php/?.?/fpm/php-fpm.conf"
         ;;
 
     *)
-        echo "$(basename $0) tkldev service wrapper falling back to /usr/sbin/service"
-        /usr/sbin/service $@
+        echo "$(basename "$0") tkldev service wrapper falling back to /usr/sbin/service"
+        /usr/sbin/service "$@"
         ;;
 esac


### PR DESCRIPTION
The `service` wrapper has been buggy since 1d459feb.

1. The order of arguments for `stop_start` is wrong for: gitlab-runsvdir, ghost, mattermost, redis.
    - It's `$1 $2` (`<service name> <action>`) instead of `$2 $1` (`<action> <service name>`) which the function expects.
    - The correct order is used for webmin which was added by 44a90b93.
2. The script fails silently which is probably the reason why the issue was not detected earlier.
    - By calling `stop_start` in the background with `&`, no exit code is returned unless one `wait`s for it later.
    - There is no `wait` later.
    - Therefore the script exits 0 even though `stop_start` failed immediately.

This commit fixes the issue which prevents e.g. the Gitlab appliance from building.

Misc fixes:
- apply shellcheck lints
- use consistent glob for PHP version
