### PR TITLE
Clean up old MariaDB bugfixes - no longer required

### DIFF
--- a/overlays/mysql/etc/mysql/conf.d/innodb-barracuda.cnf
+++ b/overlays/mysql/etc/mysql/conf.d/innodb-barracuda.cnf
@@ -1,5 +1,0 @@
-[mysqld]
-default_tmp_storage_engine = InnoDB
-innodb_file_format = Barracuda
-innodb_large_prefix = 1
-innodb_default_row_format = Dynamic

--- a/overlays/rails/usr/lib/inithooks/firstboot.d/20regen-rails-secrets
+++ b/overlays/rails/usr/lib/inithooks/firstboot.d/20regen-rails-secrets
@@ -55,8 +55,5 @@ CONF=$WEBROOT/config/database.yml
 sed -i "s|password:.*|password: $PASSWORD|g" $CONF
 $INITHOOKS_PATH/bin/mysqlconf.py --user=$APPNAME --pass="$PASSWORD"
 
-# remove innodb logfiles (workarounds really weird bug)
-rm -f /var/lib/mysql/ib_logfile*
-
 # restart passenger
 touch $WEBROOT/tmp/restart.txt

--- a/removelists/mysql
+++ b/removelists/mysql
@@ -1,1 +1,0 @@
-/var/lib/mysql/ib_logfile*


### PR DESCRIPTION
General improvements; somewhat related to https://github.com/turnkeylinux-apps/redmine/pull/29 - and also perhaps related to https://github.com/turnkeylinux/tracker/issues/1947 ?

The removal of `/var/lib/mysql/ib_logfile*` files was a bugfix for a weird issue **13 years ago**! I have just done a build without removing these files and it appears to be fine.

The `innodb-barracuda.cnf` file was to work around issues with utfmb4 on an older version of MariaDB (that didn't default to supporting it). The settings in it are now either deprecated, or the defaults.