### PR TITLE
Common updates for Fileserver and derivative appliances

### DIFF
--- a/changes/fileserver.changelog
+++ b/changes/fileserver.changelog
@@ -1,0 +1,9 @@
+turnkey-fileserver-18.0 (1) turnkey; urgency=low
+
+  * Add wsdd package for Windows Service for Devices - so Fileserver shows up
+    in Win10/11 Explorer - closes #1598.
+
+  * Install avahi-daemon by default. Provides zeroconf auto network discovery
+    and is ompatible with Apple's Bonjour service.
+
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Thu, 06 Jun 2024 07:42:44 +0000

--- a/mk/turnkey/fileserver.mk
+++ b/mk/turnkey/fileserver.mk
@@ -1,5 +1,5 @@
 WEBMIN_FW_TCP_INCOMING = 22 80 135 139 443 445 5357 12321
-WEBMIN_FW_UDP_INCOMING = 137 138 3702
+WEBMIN_FW_UDP_INCOMING = 137 138 3702 5353
 
 COMMON_OVERLAYS += samba-fileserver samba-sid-inithook samba-dav nfs
 COMMON_CONF += fileserver-storage samba-rootpass samba-webmin samba-dav nfs

--- a/mk/turnkey/fileserver.mk
+++ b/mk/turnkey/fileserver.mk
@@ -1,3 +1,6 @@
+WEBMIN_FW_TCP_INCOMING = 22 80 135 139 443 445 5357 12321
+WEBMIN_FW_UDP_INCOMING = 137 138 3702
+
 COMMON_OVERLAYS += samba-fileserver samba-sid-inithook samba-dav nfs
 COMMON_CONF += fileserver-storage samba-rootpass samba-webmin samba-dav nfs
 

--- a/plans/turnkey/fileserver
+++ b/plans/turnkey/fileserver
@@ -1,0 +1,7 @@
+#include <turnkey/samba>
+#include <turnkey/samba-dav>
+#include <turnkey/compression>
+#include <turnkey/nfs>
+
+wsdd            /* Win client discovery via Web Service Discovery */
+avahi-daemon    /* Needed for Ubuntu, Mac OSX and possibly others */

--- a/plans/turnkey/samba
+++ b/plans/turnkey/samba
@@ -5,4 +5,3 @@ webmin-samba
 samba-vfs-modules
 
 flip            /* convert line endings between unix and dos formats */
-


### PR DESCRIPTION
Consolidation of common components for fileserver, mediaserver & torrentserver:

- Update samba ports, add wsdd ports and move all common ports to `fileserver.mk`
- Create common `fileserver` plan, including wsdd

Required by:
- https://github.com/turnkeylinux-apps/fileserver/pull/14
- https://github.com/turnkeylinux-apps/mediaserver/pull/30
- https://github.com/turnkeylinux-apps/torrentserver/pull/20

Closes: https://github.com/turnkeylinux/tracker/issues/1598