### PR TITLE
Tweak mod_evasive config

### DIFF
--- a/conf/apache-security
+++ b/conf/apache-security
@@ -1,11 +1,16 @@
 #!/bin/bash -e
 
-# try to enable mod, if it's not available just continue
+# try to enable mods, if not available just continue
 a2enmod security2 || true
 a2enmod evasive || true
 
-# ensure that mod_evasive can write to log
+# tweak mod_evasive defaults
 CONF=/etc/apache2/mods-available/evasive.conf
 if [[ -f "$CONF" ]]; then
-    sed -i '\|DOSLogDir| s|#||; \|DOSLogDir| s|".*"$|"/var/log/apache2"|' $CONF
+    # enable mod_evasive logging line - but leave default
+    sed -i '/DOSLogDir/ s|#||' $CONF
+    # update default config - resolves https://github.com/turnkeylinux/tracker/issues/1951
+    sed -Ei '/DOSPageCount/ s|^(\s*)#*(DOSPageCount)(\s*)[0-9]+|\1\2\3 5|' $CONF
+    # add additional example whitelist conf
+    sed -Ei '/DOSBlockingPeriod/a\'$'\n''    #DOSWhitelist        xxx.xxx.xxx.xxx' $CONF
 fi

--- a/conf/apache-security
+++ b/conf/apache-security
@@ -7,8 +7,12 @@ a2enmod evasive || true
 # tweak mod_evasive defaults
 CONF=/etc/apache2/mods-available/evasive.conf
 if [[ -f "$CONF" ]]; then
-    # enable mod_evasive logging line - but leave default
+    # enable mod_evasive logging line using default dir
     sed -i '/DOSLogDir/ s|#||' $CONF
+    # ensure log dir exists and is writable
+    LOG_DIR=$(sed -En '/DOSLogDir/ s|^.*DOSLogDir.*"([a-z_/-]+)".*|\1|p' $CONF)
+    mkdir -p $LOG_DIR
+    chown -R $LOG_DIR
     # update default config - resolves https://github.com/turnkeylinux/tracker/issues/1951
     sed -Ei '/DOSPageCount/ s|^(\s*)#*(DOSPageCount)(\s*)[0-9]+|\1\2\3 5|' $CONF
     # add additional example whitelist conf


### PR DESCRIPTION
Closes https://github.com/turnkeylinux/tracker/issues/1951
by bumping `DOSPageCount` from (default) `2` -> `5`

Closes https://github.com/turnkeylinux/tracker/issues/1950
by using default log location (`/var/log/apache`) - uncommented `DOSLogDir` for good measure

Also added `DOSWhitelist` example - commented out.

Finally made the script executable - FWIW it didn't seem to matter, but nicer for consistency.