### PR TITLE
Improve/fix turnkey-artisan:

### DIFF
--- a/overlays/artisan/usr/local/bin/turnkey-artisan
+++ b/overlays/artisan/usr/local/bin/turnkey-artisan
@@ -7,6 +7,6 @@ export WEBROOT="/var/www" # DON"T FORGET TO UPDATE!
 export ARTISAN_USER="${ARTISAN_USER:-www-data}"
 export ARTISAN_DIR="${ARTISAN_DIR:-$WEBROOT}"
 
-COMMAND="php '$ARTISAN_DIR/artisan'"
+COMMAND="cd $WEBROOT; /usr/bin/php '$ARTISAN_DIR/artisan'"
 
-/usr/sbin/runuser $ARTISAN_USER -s /bin/bash -c "$COMMAND $(printf '%q ' "$@")"
+/usr/sbin/runuser "$ARTISAN_USER" -s /bin/bash -c "$COMMAND $(printf '%q ' "$@")"


### PR DESCRIPTION
Closes https://github.com/turnkeylinux/tracker/issues/1959

Fixes failing usage of `turnkeyartisan` usage in Usahidi:
https://github.com/turnkeylinux-apps/ushahidi/blob/master/conf.d/main#L56

- cd to WEBROOT first - Ushahidi failing build time fix
- use absolute path to php - so it will run properly if used in cron job
- apply shellcheck suggestion - even though probably irrelevant