### PR TITLE
Fix php-fpm in dummy service script used during build

### DIFF
--- a/overlays/turnkey.d/systemd-chroot/usr/local/bin/service
+++ b/overlays/turnkey.d/systemd-chroot/usr/local/bin/service
@@ -95,7 +95,7 @@ case "$1" in
             /opt/mattermost/bin/mattermost
         ;;
 
-    redis)
+    php-fpm*)
         stop_start "$2" "$1" \
             runuser www-data -s /bin/bash -c "/usr/sbin/php-fpm?.? --daemonize --fpm-config /etc/php/?.?/fpm/php-fpm.conf"
         ;;


### PR DESCRIPTION
Not sure how this happened, but the `redis` function in our build time dummy service script was trying to start php-fpm!?

This PR fixes that. Although I note that with this fixed, there isn't any handling of redis now (even though it was wrong). So perhaps redis needs an entry? Having said that, I'm assuming that it doesn't as I'm sure that it would have caused issues before now otherwise.