### PR TITLE
fix not finding vendor

### DIFF
--- a/overlays/composer/usr/local/bin/tkl-composer-squash-vendor
+++ b/overlays/composer/usr/local/bin/tkl-composer-squash-vendor
@@ -46,10 +46,7 @@ shallow_clone() {
 }
 
 cleanup() {
-    readarray -d '' vendor_dirs < <(find /var/www -type d -name vendor)
-    # only include first match and strip leading and trailing white space
-    vendor_dir="$(\
-        sed -En "s|^[[:space:]]*(.*)[[:space:]]*|\1|p" <<<"${vendor_dirs[0]}")"
+    vendor_dir="$(find /var/www -type d -name vendor | head -n 1)"
     if ! [[ -d "${vendor_dir}" ]]; then
         fatal "No vendor directory found in /var/www"
     fi


### PR DESCRIPTION
`tkl-composer-squash-vendor` currently mishandles the vendor list, returning all directories ending with "vendor" in a newline separated list, causing it to fail the following `-d` check. This simplifies the code and fixes this issue.

noted here https://github.com/turnkeylinux/common/pull/315