### PR TITLE
fix our WebDav-CGI logout not working as intended

### DIFF
--- a/conf/samba-dav
+++ b/conf/samba-dav
@@ -56,7 +56,7 @@ onclick="$.ajax({
   url: '/',
   dataType: 'json',
   async: true,
-  username: 'logout',
+  username: '',
   password: 'turnkeylinuxlogout'
 }).done(
     function() {


### PR DESCRIPTION
As explained in https://github.com/turnkeylinux/tracker/issues/2058#issuecomment-3162684474 our custom logout button in WebDav-CGI wasn't working properly.

Using a blank username resolves that.

However, IMO the root cause of the issue is that logging in with any username other than a valid samba user results in login as the guest samba user...