### PR TITLE
add cifs-utils package to samba plan - closes #1721

### DIFF
--- a/plans/turnkey/samba
+++ b/plans/turnkey/samba
@@ -3,5 +3,5 @@ samba-common-bin
 smbclient       /* useful for testing (and connecting to other shares) */
 webmin-samba
 samba-vfs-modules
-
+cifs-utils
 flip            /* convert line endings between unix and dos formats */


### PR DESCRIPTION
Add cifs-utils package to samba common plan - closes https://github.com/turnkeylinux/tracker/issues/1721