### PR TITLE
Mysqltuner fix

### DIFF
--- a/conf/mysql
+++ b/conf/mysql
@@ -1,9 +1,13 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 # download mysqltuner
 dl() {
-    [ "$FAB_HTTP_PROXY" ] && PROXY="--proxy $FAB_HTTP_PROXY"
-    cd $2; curl -L -f -O $PROXY $1; cd -
+    if [[ "$FAB_HTTP_PROXY" ]]; then
+       PROXY=(--proxy "$FAB_HTTP_PROXY")
+    fi
+    cd "$2"
+    curl -L -f -O "${PROXY[@]}" "$1"
+    cd -
 }
 
 # Install mysqltuner at "latest" tag (via gh_releases) and from core dev's

--- a/conf/mysql
+++ b/conf/mysql
@@ -6,15 +6,20 @@ dl() {
     cd $2; curl -L -f -O $PROXY $1; cd -
 }
 
-# Install mysqltuner as recommended:
-# https://github.com/major/MySQLTuner-perl#downloadinstallation
+# Install mysqltuner at "latest" tag (via gh_releases) and from core dev's
+# repo[1] - rather than separate "org" repo[2]
+#
+# [1] https://github.com/jmrenouard/MySQLTuner-perl
+# [2] https://github.com/major/MySQLTuner-perl
 BIN=/usr/local/bin
-URL="https://raw.githubusercontent.com/major/MySQLTuner-perl/master"
-dl $URL/mysqltuner.pl $BIN
-mv $BIN/mysqltuner.pl $BIN/mysqltuner
-chmod +x $BIN/mysqltuner
-dl $URL/basic_passwords.txt $BIN
-dl $URL/vulnerabilities.csv $BIN
+VERSION=$(gh_releases jmrenouard/MySQLTuner-perl | sort -V | tail -1)
+REPO="jmrenouard/MySQLTuner-perl"
+URL="https://raw.githubusercontent.com/$REPO/refs/tags/$VERSION"
+dl "$URL/mysqltuner.pl" $BIN
+mv "$BIN/mysqltuner.pl" $BIN/mysqltuner
+chmod +x "$BIN/mysqltuner"
+dl "$URL/basic_passwords.txt" $BIN
+dl "$URL/vulnerabilities.csv" $BIN
 
 # As of Debian Buster, there is no longer a /etc/init.d/mysql script, so let's
 # link the mariadb one.


### PR DESCRIPTION
This PR primarily addresses https://github.com/turnkeylinux/tracker/issues/2084 (`mysql` conf script bug) - via commit https://github.com/turnkeylinux/common/commit/77763b4bdff8de86001db6be8879b529a36a7a97.

It also includes conversion to bash and shellcheck fixes - in https://github.com/turnkeylinux/common/commit/87ea9642a313021d426c21fa17d2c9e20d266780.

However as noted in the above bug; another curl related bug also applies to the download failure - see https://github.com/turnkeylinux/tracker/issues/2083. As noted in that issue (as a "feature request" note towards the bottom) it might be best to create a standalone download script that wraps around curl. So rather than using my `dl()` function updates here, it would probably be better to just write that script - then replace all individual `dl()` functions (e.g. in appliances) everywhere.