### PR TITLE
Plan updates

### DIFF
--- a/conf/turnkey.d/README.md
+++ b/conf/turnkey.d/README.md
@@ -1,0 +1,27 @@
+Common TurnKey configuration scripts
+====================================
+
+These configuration scripts will be applied to all TurnKey appliances.
+
+Architechture family specific conf scripts
+------------------------------------------
+
+Architecture family specific conf scripts can be put in a relevant
+subdirectory here.
+
+Supported architechture families are:
+- x86 (amd64 aka x86_64)
+- arm (arm64 aka aarch64)
+
+E.g. to run a new 'amd64-only' configuration script on amd64 builds (only):
+
+```
+cd common
+mkdir -p conf/turnkey.d/x86.d
+cat > conf/turnkey.d/x86.d/amd64-only <<EOF
+# configuration script only for amd64 builds
+#
+# ...
+EOF
+chmod +x conf/turnkey.d/x86.d/amd64-only
+```

--- a/overlays/turnkey.d/README.md
+++ b/overlays/turnkey.d/README.md
@@ -1,0 +1,27 @@
+Common TurnKey overlays
+=======================
+
+These overlays will be applied to all TurnKey appliances.
+
+Architechture family specific overlays
+--------------------------------------
+
+Architecture family specific overlays can be put in a relevant
+subdirectory here.
+
+Supported architechture families are:
+- x86 (amd64 aka x86_64)
+- arm (arm64 aka aarch64)
+
+E.g. to add a new /etc/some-app/amd64-only.conf overlay that should only be
+added to amd64 builds:
+
+```
+cd common
+mkdir -p overlays/turnkey.d/x86.d/etc/some-app
+cat > overlays/turnkey.d/x86.d/etc/some-app/amd64-only.conf <<EOF
+# config only for amd64 builds
+#
+# ...
+EOF
+```

--- a/plans/turnkey/base
+++ b/plans/turnkey/base
@@ -5,28 +5,37 @@
 wget
 curl
 rsync
-zstd                    /* if installed will use to compress initramfs */
+zstd                    /* if installed will be used to compress initramfs */
 
-//di-live
-whiptail                /* di-live recommends */
-kbd                     /* di-live recommends */
-lvm2                    /* di-live recommends */
-file                    /* di-live recommends */
-eject                   /* di-live recommends */
+turnkey-keys            /* TKL keys packaged for v19.x */
+
+// Grub packages
+// * 'grub-pc' is required for legacy BIOS boot install
+// * 'grub-efi-amd64' is required for UEFI boot install
+// These grub packages conflict with one another but neither need be installed
+// within the live rootfs/squashfs - but are required for 'grub-install'.
+// We install grub-pc & ship grub-efi-amd64 deb (and deps) in the ISO.
+// If required, grub-efi-amd64 will be installed into the target chroot.
+grub-pc
+
+tkl-installer           /* new custom TKL installer - replaces di-live */
+
+efivar                  /* installer depends - ISO UEFI boot */
+lvm2                    /* installer recommends */
+file                    /* installer recommends */
+eject                   /* installer recommends */
 
 confconsole
 kbd                     /* confconsole recommends */
-//di-live                 /* confconsole recommends */
 resolvconf              /* confconsole recommends */
 
-/* Dbus is new default package in v18.x */
-dbus
+dbus                    /* dbus installed by default since v18.x */
 
-/* jiiterentropy-rngd provides entropy from cpu jitter; req'd in buster to */
-/* seed entropy in early boot (especially useful when live booting).       */
+// jiiterentropy-rngd provides entropy from cpu jitter; req'd to seed entropy
+// in early boot (especially useful when live booting).
 jitterentropy-rngd
 
-//tklbam                  /* still depends on py2 for now */
+tklbam                  /* depends on pypy2 for now */
 
 hubdns
 inithooks
@@ -49,8 +58,6 @@ nano
 ntpsec
 ncurses-term            /* support additional $TERM values */
 
-//perl-openssl-defaults   /* libnet-ssleay-perl depends (webmin depends) */
-//libnet-ssleay-perl      /* webmin depends  */
 webmin
 webmin-authentic-theme
 webmin-net


### PR DESCRIPTION
The primary point of this PR is to update the base plan to include `tkl-installer` and completely remove `di-live`. As you can see I also did some other tidying up. TKLBAM is now also enabled - however it's not well tested. Plus it adds a fair bit extra to the ISO - mostly because of it's dependency on `python3-botocore` - which includes support for every AWS service known to humankind... I have a plan to slim that down, but I'll get to that when I get a chance.

The (conf & overlay) readmes also included here aren't really relevant - or that useful - until we implement/finalize `arm64` support. But I had already done them so figured I might as well include them...