### PR TITLE
revert recent changes to conf/bootstrap_apt - causes issues with recent fab update

### DIFF
--- a/conf/bootstrap_apt
+++ b/conf/bootstrap_apt
@@ -26,6 +26,9 @@
 #       - if not the same as guest, apply relevant transition changes
 #   - NO_TURNKEY_APT_REPO <optional>:
 #       - disable TurnKey apt repos - useful during early transition
+#   - NO_PROXY <optional>:
+#       - same as APT_PROXY_OVERRIDE=disable (will override APT_PROXY_OVERRIDE
+#         if both set to different values)
 
 # Note, to install packages from backports:
 # - set 'BACKPORTS=y'; and either:
@@ -109,13 +112,13 @@ fi
 
 if [[ $deb_ver -le 10 ]] && [[ "$distro" == 'debian' ]]; then
     sec_repo="$CODENAME/updates"
-    PROXY_PORT="$(echo "$FAB_HTTPS_PROXY" | sed -En 's/.*:([0-9]+).*/\1/p')"
+    PROXY_PORT=8124
 elif [[ $deb_ver -ge 11 ]] || [[ "$distro" == 'ubuntu' ]]; then
     sec_repo="$CODENAME-security"
     PROXY_PORT=3128
 fi
 
-if [[ "${APT_PROXY_OVERRIDE,,}" == "disable" ]]; then
+if [[ "${APT_PROXY_OVERRIDE,,}" == "disable" ]] || [[ -n "$NO_PROXY" ]]; then
     PROXY_PORT=
 elif [[ -n $APT_PROXY_OVERRIDE ]]; then
     PROXY_PORT=$APT_PROXY_OVERRIDE


### PR DESCRIPTION
I haven't bothered looking into it, but with the changes to `conf/bootstrap_apt` in combination with the recent fab changes, `NO_PROXY=true` is broken. I've just tested this and reverting to the previous iteration makes it work again (with latest fab and current `19.x-dev` common).

Reverting the `PROXY_PORT=8124` line wasn't really necessary but as it only applies to Debian 9 and older it's irrelevant either way IMO...