### PR TITLE
Extend git aliases and enable autocomplete

### DIFF
--- a/overlays/turnkey.d/bashrc/etc/skel/.bashrc.d/git
+++ b/overlays/turnkey.d/bashrc/etc/skel/.bashrc.d/git
@@ -1,23 +1,51 @@
-# uncomment if not setting 'git config'
+# uncomment these or use 'git config'
 #export GIT_AUTHOR_NAME="Your Name"
 #export GIT_AUTHOR_EMAIL="your@email.com"
 #export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
 #export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
 
+if [[ -d /usr/lib/git-core ]]; then
+    export PATH=/usr/lib/git-core:$PATH
+else
+    echo "Bash completion for git disabled" >&2
+    return 1
+fi
 
-# TODO - bash completetion for these aliases
-# see:
-# /usr/share/bash-completion/completions/git
+_git_bash_complete_=/usr/share/bash-completion/completions/git
+if [[ -f "$_git_bash_complete_" ]]; then
+    # shellcheck source=/usr/share/bash-completion/completions/git
+    source "$_git_bash_complete_"
+else
+    echo "Bash completion file for git not found - $_git_bash_complete_" >&2
+fi
 
-[[ -d /usr/lib/git-core ]] && export PATH=/usr/lib/git-core:$PATH
+_complete_() {
+    # load completion/s
+    if ! [[ -f "$_git_bash_complete_" ]]; then
+        return
+    fi
+    local command="${1/_}"
+    shift
+    local aliases=("$@")
+    for alias in "${aliases[@]}"; do
+        __git_complete "$alias" "_git_$command"
+    done
+}
 
 git_branch() {
+    # default to show all branch info, but not for incompatable switches
     local args=("$@")
-    local default_args=(-a -v)
+    local default_args=(--all --verbose)
     local final_args=()
     for arg in "${args[@]}"; do
-        if [[ "$arg" == "-D" ]] || [[ "$arg" == "-d" ]]; then
-            default_args=()
+        if [[ "$arg" == "-d" ]] || [[ "$arg" == "--delete" ]] \
+            || [[ "$arg" == "-D" ]] \
+            || [[ "$arg" == "-m" ]] || [[ "$arg" == "--move" ]] \
+            || [[ "$arg" == "-M" ]] \
+            || [[ "$arg" == "-c" ]] || [[ "$arg" == "--copy" ]] \
+            || [[ "$arg" == "-C" ]] \
+            || [[ "$arg" == "-t" ]] || [[ "$arg" == "--track"* ]]; then
+                default_args=()
         fi
         final_args+=("$arg")
     done
@@ -25,18 +53,87 @@ git_branch() {
     /usr/lib/git-core/git-branch "${final_args[@]}"
 }
 
-# useful aliases
+g_alias_help() {
+    echo "git alias bashrc: ~/.bashrc.d/git"
+    echo
+    alias \
+        | sed "s|g_alias_help|show this help|" \
+        | sed -En "\|git|s|^alias ([a-z]+)='([a-z0-9_ -]+)'|  \1\t\2|p" \
+        | sed "s|git_branch|git-branch --all --verbose (except -c\|-d\|-m)|"
+}
+
+gp() {
+    cat 1>&2 <<EOF
+git alias 'gp' is ambiguous - try:
+
+git push:
+
+    gph $*
+
+git pull:
+
+    gpl $*
+EOF
+}
+
+# define aliases and enable alias bash completion
+alias gh="g_alias_help"
+
 alias ga="git-add"
-alias gb="git_branch"  # see func above
+_complete_ _add ga
+
+alias gb="git_branch"  # see git_branch func above
+alias gbb="/usr/lib/git-core/git-branch"  # to use raw 'git-branch'
+_complete_ _branch gb
+
 alias gc="git-commit"
-alias gca="git-commit -v -a"
-alias gcam="git-commit --amend -v"
+alias gca="git-commit --all --verbose"
+alias gcam="git-commit --amend --verbose"
+_complete_ _commit gc gca gcam
+
+alias gch="git-checkout"
+_complete_ _checkout gch
+
 alias gd="git-diff"
+_complete_ _diff gd
+
+alias gf="git-fetch --verbose"
+alias gfa="git-fetch --verbose --all"
+_complete_ _fetch gf
+
 alias gg="git-grep"
+_complete_ _grep gg
+
 alias gl="git-log"
 alias gll="git-log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit"
 alias glo="git-log --oneline"
-alias gr="git-remote -v"
+alias gln="git-log --name-only"
+_complete_ _log gl gll glo gln
+
+alias gm="git mv"
+_complete_ _mv gm
+
+alias gpl="git-pull"
+_complete_ _pull gpl
+
+alias gph="git-push"
+_complete_ _push gph
+
+alias gr="git-remote --verbose"
+alias gra="git-remote add"
+_complete_ _remote gr gra
+
+alias grb="git-rebase"
+alias gri="git-rebase --interactive"
+_complete_ _rebase grb gri
+
 alias gs="git-status"
+_complete_ _status gs
+
+alias gt="git-tag"
+alias gta="git-tag --add"
+alias gtm="git-tag -n5"  # show tags and 5 lines of message
+alias gts="git-tag --sign"
+_complete_ _tag gt gta gtm gts
 
 # vim:ft=bash


### PR DESCRIPTION
This is not at all important but it's what I use on my local PC so required zero effort. :grin: 


It extends on the existing `~/.bashrc.d/git` file; adds some additional aliases and provides autocomplete.

It also now passes shellcheck and prefers long options over short ones, which IMO makes it easier to see what stuff does at a glance - particularly for options that you may not be familiar with.