### PR TITLE
replace ifupdown with ifupdown-ng

### DIFF
--- a/plans/net
+++ b/plans/net
@@ -1,4 +1,5 @@
-ifupdown             # high level tools to configure network interfaces 
+ifupdown-ng          # updated drop-in replacement for ifupdown
+ifupdown-ng-compat   # compatibility with traditional ifupdown
 ethtool              # display or change ethernet card settings
 bind9-host           # Version of 'host' bundled with BIND 9.X
 netbase              # Basic TCP/IP networking system


### PR DESCRIPTION
Replace `ifupdown` with `ifupdown-ng`. It's pretty much a drop in replacement, but the `ifupdown-ng-compat` provides full backwards compatibility - so no other code changes are required.

Closes https://github.com/turnkeylinux/tracker/issues/1992