### PR TITLE
fix: route PostgreSQL start/stop through fake systemctl/service in chroot

### DIFF
--- a/conf/pgsql
+++ b/conf/pgsql
@@ -7,8 +7,8 @@ CONF_DIR=/etc/postgresql/${PGSQL_VER}/main
 
 # Recreate postgres and templates using UTF-8
 pg_dropcluster --stop ${PGSQL_VER} main || true
-pg_createcluster --start -e UTF-8 ${PGSQL_VER} main
-/etc/init.d/postgresql stop
+pg_createcluster -e UTF-8 ${PGSQL_VER} main
+systemctl start postgresql
 
 # Enable password encryption
 sed -i "/^#password_encryption = on/ s/#//" $CONF_DIR/postgresql.conf
@@ -16,9 +16,10 @@ sed -i "/^#password_encryption = on/ s/#//" $CONF_DIR/postgresql.conf
 # Reduce shared_buffers (better than increasing /proc/sys/kernel/shmmax)
 sed -i "/^shared_buffers =/ s/32/24/" $CONF_DIR/postgresql.conf
 
-# Configure postgres password
-/etc/init.d/postgresql start
+# Reload config after changes
+systemctl restart postgresql
 
+# Configure postgres password
 su postgres -c 'psql postgres' << EOF
 alter user postgres with encrypted password '$PGSQL_PASS';
 EOF
@@ -27,4 +28,4 @@ EOF
 su postgres -c "createuser --superuser root"
 su postgres -c "createdb root"
 
-/etc/init.d/postgresql stop
+systemctl stop postgresql

--- a/overlays/turnkey.d/systemd-chroot/usr/local/bin/service
+++ b/overlays/turnkey.d/systemd-chroot/usr/local/bin/service
@@ -128,6 +128,28 @@ case "$1" in
                                 " --fpm-config /etc/php/?.?/fpm/php-fpm.conf"
         ;;
 
+    postgresql)
+        PG_VER=$(ls /usr/lib/postgresql/)
+        PG_BIN="/usr/lib/postgresql/$PG_VER/bin/pg_ctl"
+        PG_DATA="/var/lib/postgresql/$PG_VER/main"
+        PG_CONF="/etc/postgresql/$PG_VER/main"
+        case "$2" in
+            start)
+                su postgres -c "$PG_BIN start -w -D $PG_DATA -o '-c config_file=$PG_CONF/postgresql.conf'"
+                ;;
+            stop)
+                su postgres -c "$PG_BIN stop -w -D $PG_DATA"
+                ;;
+            restart)
+                su postgres -c "$PG_BIN restart -w -D $PG_DATA -o '-c config_file=$PG_CONF/postgresql.conf'"
+                ;;
+            *)
+                echo "unexpected postgresql command '$2'" >&2
+                exit 1
+                ;;
+        esac
+        ;;
+
     *)
         echo "[$*] - unrecognized service = tkldev '$(basename "$0")'" \
              " wrapper falling back to /usr/sbin/service"


### PR DESCRIPTION
## Summary

- Add `postgresql)` case to the build-time fake `service` wrapper (`overlays/turnkey.d/systemd-chroot/usr/local/bin/service`) that calls `pg_ctl` directly, bypassing the PID-file validation that breaks inside the FAB chroot
- Update `conf/pgsql` to use `systemctl start/stop/restart postgresql` instead of `/etc/init.d/postgresql` calls

## Problem

`/etc/init.d/postgresql stop` and `pg_ctlcluster stop` both fail with **"pid file is invalid"** inside the FAB chroot because `/proc` is shared with the host. The PID file written by PostgreSQL contains the host-namespace PID, which the stop wrappers cannot validate against the chroot's `/proc`.

## Approach

Per @JedMeister's feedback on #347, this PR uses the existing fake `systemctl`/`service` infrastructure rather than calling `pg_ctl` directly from `conf/pgsql`. The call chain is:

```
conf/pgsql → systemctl start postgresql → fake service postgresql start → pg_ctl start
```

This keeps service management consistent with how other services (apache2, postfix, mariadb, etc.) are handled during builds.

## Changes

1. **`overlays/turnkey.d/systemd-chroot/usr/local/bin/service`** — new `postgresql)` case that resolves the PostgreSQL version at runtime and calls `pg_ctl` via `su postgres` for `start`, `stop`, and `restart`
2. **`conf/pgsql`** — replace all `/etc/init.d/postgresql` calls with `systemctl`; remove `--start` from `pg_createcluster` (start explicitly via `systemctl` instead); add `systemctl restart` after config changes so they take effect

## Test plan

- [ ] Full appliance build with PostgreSQL (e.g., NetBox) completes successfully
- [ ] PostgreSQL cluster creation, password config, user creation, and clean shutdown all work inside FAB chroot
- [ ] No regressions in other services managed by the fake `service` wrapper

Supersedes #347 (clean branch from `19.x-dev` with only the PostgreSQL fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)