### PR TITLE
Adminer (mostly...)

### DIFF
--- a/conf/adminer
+++ b/conf/adminer
@@ -21,3 +21,14 @@ touch /var/log/adminer/{access.log,error.log}
 chown -R root:adm /var/log/adminer
 chmod 755 /var/log/adminer
 chmod 644 /var/log/adminer/*.log
+
+# Configure fail2ban protection for Adminer
+cat >> /etc/fail2ban/jail.local <<EOF
+
+[adminer-auth]
+enabled     = true
+port        = 12322
+action      = iptables[name=adminer, port=12322, protocol=tcp]
+filter      = adminer-auth
+maxretry    = 3
+EOF

--- a/conf/adminer
+++ b/conf/adminer
@@ -11,6 +11,7 @@ ln -sf $ADMINER_DIR/designs/nette/adminer.css $STATIC_DIR/default.css
 ln -sf /etc/adminer/adminer.css /usr/share/adminer/adminer/adminer.css
 
 # Ensure www-data has read access to php files in /etc/adminer
+chown -R root:adm /etc/adminer
 chown root:www-data /etc/adminer /etc/adminer/tkl-*.php /etc/adminer/adminer.css
 chmod 755 /etc/adminer
 chmod 644 /etc/adminer/tkl-*.php /etc/adminer/adminer.css

--- a/conf/adminer
+++ b/conf/adminer
@@ -10,7 +10,14 @@ ln -sf $ADMINER_DIR/designs/nette/adminer.css $STATIC_DIR/default.css
 
 ln -sf /etc/adminer/adminer.css /usr/share/adminer/adminer/adminer.css
 
-# ensure www-data has read access to php files in /etc/adminer
+# Ensure www-data has read access to php files in /etc/adminer
 chown root:www-data /etc/adminer /etc/adminer/tkl-*.php /etc/adminer/adminer.css
 chmod 755 /etc/adminer
 chmod 644 /etc/adminer/tkl-*.php /etc/adminer/adminer.css
+
+# Set up custom Adminer specific logging (config in relevant webserver vhosts)
+mkdir -p /var/log/adminer
+touch /var/log/adminer/{access.log,error.log}
+chown -R root:adm /var/log/adminer
+chmod 755 /var/log/adminer
+chmod 644 /var/log/adminer/*.log

--- a/conf/adminer
+++ b/conf/adminer
@@ -18,7 +18,7 @@ chmod 644 /etc/adminer/tkl-*.php /etc/adminer/adminer.css
 # Set up custom Adminer specific logging (config in relevant webserver vhosts)
 mkdir -p /var/log/adminer
 touch /var/log/adminer/{access.log,error.log}
-chown -R root:adm /var/log/adminer
+chown -R www-data:www-data /var/log/adminer
 chmod 755 /var/log/adminer
 chmod 644 /var/log/adminer/*.log
 

--- a/conf/adminer-lighttpd
+++ b/conf/adminer-lighttpd
@@ -6,3 +6,4 @@ sed -i 's|^[[:space:]]*#([[:space:]]*"mod_redirect".*)|\1|' /etc/lighttpd/lightt
 # Link conf file to available-sites, and enable it
 ln -s /etc/adminer/lighttpd.conf /etc/lighttpd/conf-available/50-adminer.conf
 lighty-enable-mod adminer || true
+lighty-enable-mod accesslog

--- a/conf/adminer-lighttpd
+++ b/conf/adminer-lighttpd
@@ -7,3 +7,6 @@ sed -Ei 's|^[[:space:]]*#([[:space:]]*"mod_redirect".*)|\1|' /etc/lighttpd/light
 ln -s /etc/adminer/lighttpd.conf /etc/lighttpd/conf-available/50-adminer.conf
 lighty-enable-mod adminer || true
 lighty-enable-mod accesslog
+
+# Lighty doesn't support aliases, so we need to symlink tkl-index
+ln -sf /etc/adminer/tkl-index.php /usr/share/adminer/adminer/tkl-index.php

--- a/conf/adminer-lighttpd
+++ b/conf/adminer-lighttpd
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # Ensure redirection is enabled
-sed -i 's|^[[:space:]]*#([[:space:]]*"mod_redirect".*)|\1|' /etc/lighttpd/lighttpd.conf
+sed -Ei 's|^[[:space:]]*#([[:space:]]*"mod_redirect".*)|\1|' /etc/lighttpd/lighttpd.conf
 
 # Link conf file to available-sites, and enable it
 ln -s /etc/adminer/lighttpd.conf /etc/lighttpd/conf-available/50-adminer.conf

--- a/conf/turnkey.d/fail2ban-fixes
+++ b/conf/turnkey.d/fail2ban-fixes
@@ -8,28 +8,6 @@ if ! grep -q '^allowipv6' $CONF; then
     sed -i '\|^\[Definition\]|a \\nallowipv6 = auto' $CONF
 fi
 
-# ensure that fail2ban blocks known users with incorrect key - see Debian
-# Bug #1038779 - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1038779
-
-cat > fail2ban.patch <<EOF
---- /etc/fail2ban/filter.d/sshd.conf.orig
-+++ /etc/fail2ban/filter.d/sshd.conf
-@@ -97,9 +97,9 @@
- # consider failed publickey for invalid users only:
- cmnfailre-failed-pub-invalid = ^Failed publickey for invalid user <F-USER>(?P<cond_user>\S+)|(?:(?! from ).)*?</F-USER> from <HOST>%(__on_port_opt)s(?: ssh\d*)?(?(cond_user): |(?:(?:(?! from ).)*)$)
- # consider failed publickey for valid users too (don't need RE, see cmnfailed):
--cmnfailre-failed-pub-any =
-+cmnfailre-failed-pub-any = ^Failed publickey for <F-USER>(?P<cond_user>\S+)|(?:(?! from ).)*?</F-USER> from <HOST>%(__on_port_opt)s(?: ssh\d*)?(?(cond_user): |(?:(?:(?! from ).)*)$)
- # same as invalid, but consider failed publickey for valid users too, just as no failure (helper to get IP and user-name only, see cmnfailed):
--cmnfailre-failed-pub-nofail = <cmnfailre-failed-pub-invalid>
-+cmnfailre-failed-pub-nofail = <cmnfailre-failed-pub-any>
- # don't consider failed publickey as failures (don't need RE, see cmnfailed):
- cmnfailre-failed-pub-ignore =
-
-EOF
-git apply fail2ban.patch
-rm fail2ban.patch
-
 cat > /etc/cron.weekly/fail2ban <<EOF
 #!/bin/sh
 #

--- a/conf/turnkey.d/fail2ban-fixes
+++ b/conf/turnkey.d/fail2ban-fixes
@@ -1,13 +1,5 @@
 #!/bin/bash -e
 
-# explictly allow ipv6 - see Debian bug #1024305:
-# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1024305
-
-CONF=/etc/fail2ban/fail2ban.conf
-if ! grep -q '^allowipv6' $CONF; then
-    sed -i '\|^\[Definition\]|a \\nallowipv6 = auto' $CONF
-fi
-
 cat > /etc/cron.weekly/fail2ban <<EOF
 #!/bin/sh
 #

--- a/overlays/adminer/etc/adminer/apache.conf
+++ b/overlays/adminer/etc/adminer/apache.conf
@@ -6,6 +6,9 @@
     Alias /adminer/static /usr/share/adminer/adminer/static
     Alias /externals /usr/share/adminer/externals
     Alias /editor   /usr/share/adminer/editor
+
+    CustomLog /var/log/adminer/access.log combined
+    ErrorLog /var/log/adminer/error.log
 </VirtualHost>
 
 <Directory /etc/adminer>

--- a/overlays/adminer/etc/adminer/lighttpd.conf
+++ b/overlays/adminer/etc/adminer/lighttpd.conf
@@ -8,25 +8,11 @@ var.alias_redirects = (
     "/externals/"       => "/usr/share/adminer/externals/"
 )
 
-# Map tkl-index.php URL to the actual file in /etc/adminer/
-$HTTP["url"] == "/tkl-index.php" {
-    fastcgi.server = (
-        ".php" => ((
-            "socket" => "/run/php/php-fpm.sock", # may need adjustment?
-            "check-local" => "disable",
-            "bin-environment" => (
-                "SCRIPT_FILENAME" => "/etc/adminer/tkl-index.php"
-            )
-        ))
-    )
-}
-
-index-file.names += ( "tkl-index.php" )
-
 # IPv4
 $SERVER["socket"] == "0.0.0.0:12322" {
     ssl.engine = "enable"
     server.document-root = "/usr/share/adminer/adminer/"
+    index-file.names = ( "tkl-index.php", "index.php" )
     alias.url = alias_redirects
     follow-symlink = "enable"
 
@@ -38,6 +24,7 @@ $SERVER["socket"] == "0.0.0.0:12322" {
 $SERVER["socket"] == "[::]:12322" {
     ssl.engine = "enable"
     server.document-root = "/usr/share/adminer/adminer/"
+    index-file.names = ( "tkl-index.php", "index.php" )
     alias.url = alias_redirects
     follow-symlink = "enable"
 

--- a/overlays/adminer/etc/adminer/lighttpd.conf
+++ b/overlays/adminer/etc/adminer/lighttpd.conf
@@ -29,6 +29,9 @@ $SERVER["socket"] == "0.0.0.0:12322" {
     server.document-root = "/usr/share/adminer/adminer/"
     alias.url = alias_redirects
     follow-symlink = "enable"
+
+    accesslog.filename = "/var/log/adminer/access.log"
+    server.errorlog = "/var/log/adminer/error.log"
 }
 
 # IPv6
@@ -37,4 +40,7 @@ $SERVER["socket"] == "[::]:12322" {
     server.document-root = "/usr/share/adminer/adminer/"
     alias.url = alias_redirects
     follow-symlink = "enable"
+
+    accesslog.filename = "/var/log/adminer/access.log"
+    server.errorlog = "/var/log/adminer/error.log"
 }

--- a/overlays/adminer/etc/adminer/nginx.conf
+++ b/overlays/adminer/etc/adminer/nginx.conf
@@ -16,9 +16,10 @@ server {
 
     # Route tkl-index.php to /etc/adminer/
     location = /tkl-index.php {
+        include /etc/nginx/snippets/fastcgi-php.conf;
         fastcgi_param HTTPS on;
         fastcgi_param SCRIPT_FILENAME /etc/adminer/tkl-index.php;
-        include /etc/nginx/snippets/php-fpm.conf;
+        fastcgi_pass unix:/run/php/php-fpm.sock;
     }
 
     location ~ \.php$ {

--- a/overlays/adminer/etc/adminer/nginx.conf
+++ b/overlays/adminer/etc/adminer/nginx.conf
@@ -5,7 +5,9 @@ server {
     listen [::]:12322 ssl;
     include /etc/nginx/snippets/ssl.conf;
     root /usr/share/adminer/adminer/;
-    error_log /var/log/nginx/adminer-error.log;
+
+    access_log /var/log/adminer/access.log;
+    error_log /var/log/adminer/error.log;
 
     location / {
         index tkl-index.php index.php;

--- a/overlays/adminer/etc/fail2ban/filter.d/adminer-auth.conf
+++ b/overlays/adminer/etc/fail2ban/filter.d/adminer-auth.conf
@@ -1,0 +1,12 @@
+# Fail2Ban filter for adminer
+#
+# Provided by TurnKey GNU/Linux
+# Works for Apache2, LigHTTPd & Nginx access logs
+
+[INCLUDES]
+before = common.conf
+
+[Definition]
+failregex = ^<HOST> .* "POST /adminer\.php.*" (200|302) .*$
+
+ignoreregex =

--- a/overlays/adminer/etc/logrotate.d/adminer
+++ b/overlays/adminer/etc/logrotate.d/adminer
@@ -1,0 +1,23 @@
+/var/log/adminer/access.log
+/var/log/adminer/error.log {
+    weekly
+    rotate 4
+    compress
+    missingok
+    notifempty
+    sharedscripts
+    postrotate
+        # Apache
+        if systemctl is-active --quiet apache2; then
+            systemctl reload apache2
+        fi
+        # Nginx
+        if systemctl is-active --quiet nginx; then
+            systemctl reload nginx
+        fi
+        # Lighttpd
+        if systemctl is-active --quiet lighttpd; then
+            systemctl reload lighttpd
+        fi
+    endscript
+}

--- a/overlays/lighttpd/etc/lighttpd/ssl-params.conf
+++ b/overlays/lighttpd/etc/lighttpd/ssl-params.conf
@@ -14,7 +14,7 @@ ssl.openssl.ssl-conf-cmd = ("MinProtocol" => "TLSv1.2")
 # See https://wiki.lighttpd.net/Docs_SSL
 # Uncomment to better match the less restricted Mozilla intermediate spec.
 # (TKL Ciphers set by common/conf/turnkey.d/zz-ssl-ciphers)
-#ssl.openssl.ssl-conf-cmd += ("CipherString" => "ZZ_SSL_CIPHERS")
+ssl.openssl.ssl-conf-cmd += ("CipherString" => "ZZ_SSL_CIPHERS")
 
 # HSTS config + additional hardening
 server.modules += ("mod_redirect")

--- a/overlays/lighttpd/etc/lighttpd/ssl-params.conf
+++ b/overlays/lighttpd/etc/lighttpd/ssl-params.conf
@@ -5,7 +5,6 @@
 
 ssl.pemfile = "/etc/ssl/private/cert.pem"
 ssl.privkey = "/etc/ssl/private/cert.key"
-ssl.dh-file = "/etc/ssl/private/dhparams.pem"
 
 ssl.openssl.ssl-conf-cmd = ("MinProtocol" => "TLSv1.2")
 # lighttpd 1.4.79 TLS default appends X448

--- a/overlays/nginx/etc/nginx/sites-available/tkl-default
+++ b/overlays/nginx/etc/nginx/sites-available/tkl-default
@@ -18,14 +18,18 @@
 ##
 
 # Default server configuration
-#
+
+# HTTP
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
-
+    server_name _;
     # temporary redirect to https - update to permanent (308) for production
     return 307 https://$host$request_uri;
+}
 
+# HTTPS
+server {
     # SSL configuration
     listen 443 ssl default_server;
     listen [::]:443 ssl default_server;
@@ -33,8 +37,8 @@ server {
 
     root /var/www;
 
-    # Ensure index.php is at the end of this list if using php-fpm
-    index index.html index.htm;
+    # index.php can be removed from the end of this list when not using php-fpm
+    index index.html index.htm index.php;
 
     server_name _;
 
@@ -44,8 +48,8 @@ server {
         try_files $uri $uri/ =404;
     }
 
-    # Uncomment to enable PHP-FPM
-    #include snippets/php-fpm.conf;
+    # Comment to disable PHP-FPM
+    include snippets/php-fpm.conf;
 
     # Deny access to all dot files
     location ~ /\. {


### PR DESCRIPTION
This is built on top of #356 - so it may be best to review that first?

- adminer specific logging - common to all webservers
- adminer log rotation
- adminer fail2ban conf to protect adminer against brute force attacks - works with all webservers
- LigHTTPd specific adminer conf fixes (plus enable TKL configured ciphers by default on LigHTTPd)
- removed redundant fail2ban bugfixes from `conf/turnkey.d/fail2ban-fixes` (both fixed in Debian).
- Nginx related fixes/adjustments - refactor default config, enable php-fpm by default & fix adminer conf