### PR TITLE
Add postfix conf script port 25 check

### DIFF
--- a/conf/turnkey.d/postfix-local
+++ b/conf/turnkey.d/postfix-local
@@ -1,8 +1,13 @@
 #!/bin/bash -e
 
+fatal() { "'$(basename "$0")' Error: $*" >&2; exit 1; }
+
 if [[ ! "$HOSTNAME" ]]; then
-    echo "'$(basename "$0")' error: hostname not defined"
-    return 1
+    fatal "Hostname not defined"
+fi
+
+if ! grep -q ':25' <(ss -tlnp); then
+    fatal "Port 25 is already in use - must be available to set up postfix"
 fi
 
 postconf -e inet_interfaces=localhost

--- a/conf/turnkey.d/postfix-local
+++ b/conf/turnkey.d/postfix-local
@@ -2,11 +2,11 @@
 
 fatal() { "'$(basename "$0")' Error: $*" >&2; exit 1; }
 
-if [[ ! "$HOSTNAME" ]]; then
+if [[ -z "$HOSTNAME" ]]; then
     fatal "Hostname not defined"
 fi
 
-if ! grep -q ':25' <(ss -tlnp); then
+if grep -q ':25' <(ss -tlnp); then
     fatal "Port 25 is already in use - must be available to set up postfix"
 fi
 


### PR DESCRIPTION
Adds a check to ensure that port 25 is free. Previously it would silently error and postfix had particularly unhelpful error message so it was a PITA to debug!

FWIW I had to `fab-investigate` my `root.patched`, install rsyslog, start it running, rerun postfix and read the resulting log. One of the downsides of systemd journal...