### PR TITLE
Webmin related updates

### DIFF
--- a/conf/turnkey.d/webmin-fw
+++ b/conf/turnkey.d/webmin-fw
@@ -84,3 +84,15 @@ done
 # See https://github.com/webmin/webmin/issues/1097
 update-alternatives --set iptables /usr/sbin/iptables-legacy
 update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+# Override default Webmin firewall services to ensure both are started.
+# (service runs create a lock file; which will cause the other service to fail)
+for firewall_conf in iptables ip6tables; do
+    CONF="/etc/systemd/system/webmin-${firewall_conf}.service.d/override.conf"
+    mkdir -p "$(dirname $CONF)"
+    cat > "$CONF" <<EOF
+[Service]
+Restart=on-failure
+RestartSec=5s
+EOF
+done

--- a/conf/turnkey.d/webmin-fw
+++ b/conf/turnkey.d/webmin-fw
@@ -18,6 +18,7 @@ tr ' ' '\n' <<<"$WEBMIN_FW_TCP_INCOMING" \
 shopt -u lastpipe
 
 # iptables-persistent package compatible config
+mkdir -p /etc/iptables
 for conf in /etc/iptables/rules.v4 /etc/iptables/rules.v6; do
     if [[ "$conf" == *"rules.v6" ]]; then
         # IPv6 should all accept all ICMPv6 types, not just echo-request

--- a/conf/turnkey.d/webmin-user-conf
+++ b/conf/turnkey.d/webmin-user-conf
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+# Auto logout user after 30 mins - allow user to override via "remember me"
+# checkbox on log in screen
+
+cat >> /etc/webmin/miniserv.conf <<EOF
+noremember=0
+logouttime=30
+EOF

--- a/overlays/turnkey.d/interfaces/etc/network/interfaces
+++ b/overlays/turnkey.d/interfaces/etc/network/interfaces
@@ -7,13 +7,11 @@ iface lo inet loopback
 auto eth0
 iface eth0 inet dhcp
     hostname _UNCONFIGURED_
-
 iface eth0 inet6 dhcp
     hostname _UNCONFIGURED_
 
 allow-hotplug eth1
 iface eth1 inet dhcp
     hostname _UNCONFIGURED_
-
 iface eth1 inet6 dhcp
     hostname _UNCONFIGURED_

--- a/plans/turnkey/base
+++ b/plans/turnkey/base
@@ -84,7 +84,6 @@ libfile-mimeinfo-perl   /* webmin-filemin requires to extract archives */
 logrotate
 
 iptables
-iptables-persistent
 webmin-firewall
 webmin-firewall6
 fail2ban

--- a/plans/turnkey/base
+++ b/plans/turnkey/base
@@ -76,6 +76,7 @@ webmin-tklbam
 webmin-updown
 webmin-filemin
 webmin-logviewer
+webmin-systemd          /* new systemd unit module in v19.x */
 webmin-xterm            /* interactive terminal module */
 fdisk                   /* webmin-fdisk recommends */
 unzip                   /* webmin-updown recommends */


### PR DESCRIPTION
Apologies for poor branch name and grab bag of changes...

- auto-expire webmin login\[1\]
- don't install `iptables-persistent` (causes issues if Webmin firewall start on boot enabled)
- install `webmin-systemd` package - manage systemd via webmin
- remove additional newlines in interfaces file
- ensure firewall config dir exists (not sure why but a recent build failed because it didn't?!)
- resolve boot time race condition when both ipv4 & ipv6 firewalls enabled via webmin

---

1. Previously login would never expire. Expiry can be disabled by checking the "remember me" checkbox on the login screen. And/or log in timeout can be adjusted or disabled via: 
   > Webmin >> Webmin Configuration >> Authentication >>  Auto-logout after X minutes of inactivity (under "Authentication options")