### PR TITLE
Add wsdd-daemon package

### DIFF
--- a/plans/turnkey/fileserver
+++ b/plans/turnkey/fileserver
@@ -4,4 +4,5 @@
 #include <turnkey/nfs>
 
 wsdd            /* Win client discovery via Web Service Discovery */
+wsdd-server     /* Daemon split out into separate package... */
 avahi-daemon    /* Needed for Ubuntu, Mac OSX and possibly others */


### PR DESCRIPTION
The wsdd package (required for Windows to find fileserver via "network browsing") has been separated into 2 packages. They separated out the core functionality and the daemon. But in their infinite wisdom they kept the existing package name for the core/common functionality and (re)named the daemon package (required for previous functionality). Anyway, enough bitching from me...

Also FYI, wsdd didn't make it into trixie (an rc bug just before release). So I've rebuilt the Debian forky (testing) package source against trixie and pushed to our trixie main repo.