### PR TITLE
Bump TKL NodeJS landing page dep to resolve security issue

### DIFF
--- a/overlays/nodejs-pm2-tklwebcp/opt/tklweb-cp/package.json
+++ b/overlays/nodejs-pm2-tklwebcp/opt/tklweb-cp/package.json
@@ -5,7 +5,7 @@
   , "dependencies": {
       "express": ">= 4.20.0"
     , "pug": "3.x.x"
-    , "body-parser": ">= 1.20.3"
+    , "body-parser": ">= 1.20.6"
     , "method-override": ">= 3.0.0"
     , "errorhandler": ">= 1.5.0"
   }


### PR DESCRIPTION
Considering the context of our usage, this is unlikely to be an issue, but let's not use insecure deps anyway...

FYI the issue with body-parser < 1.20.6 is "denial of service when invalid limit value silently disables size enforcement".