### PR TITLE
Remove redundant LigHTTPd conf lines (modules already enabled elsewhere)

### DIFF
--- a/overlays/lighttpd/etc/lighttpd/ssl-params.conf
+++ b/overlays/lighttpd/etc/lighttpd/ssl-params.conf
@@ -17,8 +17,6 @@ ssl.openssl.ssl-conf-cmd = ("MinProtocol" => "TLSv1.2")
 ssl.openssl.ssl-conf-cmd += ("CipherString" => "ZZ_SSL_CIPHERS")
 
 # HSTS config + additional hardening
-server.modules += ("mod_redirect")
-server.modules += ("mod_setenv")
 $HTTP["scheme"] == "https" {
   # HTTP Strict Transport Security (63072000 seconds)
   setenv.add-response-header = (


### PR DESCRIPTION
`mod_redirect` & `mod_setenv` already enabled elsewhere, so they are redundant here - plus they were causing a deprecation warning. It was only a warning but may as well fix it now...